### PR TITLE
Fixed prepatch warnings always showing regardless of exe build

### DIFF
--- a/src/Utils/RMC/RMCConfigs.as
+++ b/src/Utils/RMC/RMCConfigs.as
@@ -23,11 +23,13 @@ class RMCConfig {
             for (uint j = 0; j < map.Tags.Length; j++)
                 if (map.Tags[j].ID == prepatchMapTags[i].ID) {
                     // Check ExeBuild
-                    ExeBuild@ exebuild = ExeBuild(prepatchMapTags[i].ExeBuild);
-                    Time::Info todayInfo = Time::Parse();
-                    Date@ today = Date(todayInfo.Year, todayInfo.Month, todayInfo.Day);
-                    Date@ exeBuildDate = Date(exebuild.year, exebuild.month, exebuild.day);
-                    return exeBuildDate.isBefore(today);
+                    ExeBuild exebuildConfig(prepatchMapTags[i].ExeBuild);
+                    ExeBuild exebuildMap(map.ExeBuild);
+
+                    Date@ exeBuildConfig = Date(exebuildConfig.year, exebuildConfig.month, exebuildConfig.day);
+                    Date@ exeBuildMap = Date(exebuildMap.year, exebuildMap.month, exebuildMap.day);
+
+                    return exeBuildMap.isBefore(exeBuildConfig);
                 }
         return false;
     }


### PR DESCRIPTION
This fixes prepatch warnings showing on every ice map regardless of the map's exe build.

![image](https://user-images.githubusercontent.com/136534/234091130-7a88a922-9daf-4040-94f9-7aea0a4bdb23.png)
