### PR TITLE
Minor UI improvements and added MapDate

### DIFF
--- a/src/Interface/Views/MainUI.as
+++ b/src/Interface/Views/MainUI.as
@@ -53,7 +53,6 @@ namespace MainUIView
 
     void RecentlyPlayedMapsTab()
     {
-        UI::Text("Recently played maps");
         if (DataJson.GetType() != Json::Type::Null && DataJson["recentlyPlayed"].Length > 0 && UI::BeginTable("RecentlyPlayedMaps", 5, UI::TableFlags::ScrollX | UI::TableFlags::NoKeepColumnsVisible)) {
             UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthStretch);
             UI::TableSetupColumn("Created by", UI::TableColumnFlags::WidthStretch);

--- a/src/Settings/RMCParameters.as
+++ b/src/Settings/RMCParameters.as
@@ -25,6 +25,9 @@ namespace PluginSettings
     bool RMC_DisplayMapTimeSpent = true;
 
     [Setting hidden]
+    bool RMC_DisplayMapDate = true;
+
+    [Setting hidden]
     int RMC_SurvivalMaxTime = 15;
 
     [Setting hidden]
@@ -104,6 +107,7 @@ namespace PluginSettings
                 RMC_AlwaysShowBtns = true;
                 RMC_SurvivalShowSurvivedTime = true;
                 RMC_DisplayMapTimeSpent = true;
+                RMC_DisplayMapDate = true;
                 RMC_TagsLength = 1;
                 RMC_ImageSize = 20;
             }
@@ -111,7 +115,7 @@ namespace PluginSettings
             RMC_AlwaysShowBtns = UI::Checkbox("Always show the buttons (even when the Openplanet overlay is hidden)", RMC_AlwaysShowBtns);
             RMC_SurvivalShowSurvivedTime = UI::Checkbox("Display the time survived in Survival mode", RMC_SurvivalShowSurvivedTime);
             RMC_DisplayMapTimeSpent = UI::Checkbox("Display the time spent on the actual map", RMC_DisplayMapTimeSpent);
-
+            RMC_DisplayMapDate = UI::Checkbox("Display the date the map was last updated", RMC_DisplayMapDate);
             UI::SetNextItemWidth(100);
             RMC_TagsLength = UI::SliderInt("Display Map Tags Length (0: hidden)", RMC_TagsLength, 0, 3);
 

--- a/src/Utils/RMC/RMC.as
+++ b/src/Utils/RMC/RMC.as
@@ -17,6 +17,14 @@ class RMC
 
     int TimeLimit() { return 60 * 60 * 1000; }
 
+    string IsoDateToDMY(string isoDate) 
+    {
+        string year = isoDate.SubStr(0, 4);
+        string month = isoDate.SubStr(5, 2);
+        string day = isoDate.SubStr(8, 2);
+        return day + "-" + month + "-" + year;
+    } 
+
     void Render()
     {
         string lastLetter = tostring(RMC::selectedGameMode).SubStr(0,1);
@@ -124,7 +132,11 @@ class RMC
                     MX::MapInfo@ CurrentMapFromJson = MX::MapInfo(DataJson["recentlyPlayed"][0]);
                     if (CurrentMapFromJson !is null) {
                         UI::Text(CurrentMapFromJson.Name);
-                        UI::TextDisabled("by " + CurrentMapFromJson.Username);
+                        if( PluginSettings::RMC_DisplayMapDate) {
+                            UI::TextDisabled("On " + IsoDateToDMY(CurrentMapFromJson.UpdatedAt));
+                            UI::SameLine();
+                        }
+                        UI::TextDisabled("by " + CurrentMapFromJson.Username);    
 #if TMNEXT
                         if (PluginSettings::RMC_PrepatchTagsWarns && RMC::config.isMapHasPrepatchMapTags(CurrentMapFromJson)) {
                             RMCConfigMapTag@ prepatchTag = RMC::config.getMapPrepatchMapTag(CurrentMapFromJson);

--- a/src/Utils/RMC/RMS.as
+++ b/src/Utils/RMC/RMS.as
@@ -22,19 +22,24 @@ class RMS : RMC
                 UI::Dummy(vec2(0, 8));
                 UI::PushFont(g_fontHeaderSub);
                 UI::Text(RMC::FormatTimer(SurvivedTime));
+                UI::SetPreviousTooltip("Total time survived");
             } else {
                 UI::Dummy(vec2(0, 8));
+            }
+            if (PluginSettings::RMC_DisplayMapTimeSpent) {
+                if(SurvivedTime > 0 && PluginSettings::RMC_SurvivalShowSurvivedTime) {
+                    UI::SameLine();
+                }
+                UI::PushFont(g_fontHeaderSub);
+                UI::Text(Icons::Map + " " + RMC::FormatTimer(RMC::TimeSpentMap));
+                UI::SetPreviousTooltip("Time spent on this map");
+                UI::PopFont();
             }
         } else {
             UI::TextDisabled(RMC::FormatTimer(TimeLimit()));
             UI::Dummy(vec2(0, 8));
         }
-        if (PluginSettings::RMC_DisplayMapTimeSpent) {
-            UI::PushFont(g_fontHeaderSub);
-            UI::Text(Icons::Map + " " + RMC::FormatTimer(RMC::TimeSpentMap));
-            UI::SetPreviousTooltip("Time spent on this map");
-            UI::PopFont();
-        }
+        
         UI::PopFont();
     }
 


### PR DESCRIPTION
Very minor PR to move the map timer next to the total timer to save screen space. In addition, I added a date to the map information as some maps are broken due to earlier physics patches. Players with knowledge of the game can quickly estimate what physics the Author medal was driven in. I also added an option to remove the date. 

This PR is mostly to experiment with the codebase before considering more fun contributions. 

![image](https://user-images.githubusercontent.com/29886335/234923833-a1a3fdbc-d049-4a8b-855e-a5f5071e64dc.png)

