### PR TITLE
Scaling fixes

### DIFF
--- a/src/Interface/ModalDialogs/DataMigrationWizardModalDialog.as
+++ b/src/Interface/ModalDialogs/DataMigrationWizardModalDialog.as
@@ -109,7 +109,8 @@ class DataMigrationWizardModalDialog : ModalDialog
 
     void RenderDialog() override
     {
-        UI::BeginChild("Content", vec2(0, -32));
+        float scale = UI::GetScale();
+        UI::BeginChild("Content", vec2(0, -32) * scale);
 		switch (m_stage) {
 			case 0: RenderStep1(); break;
 			case 1: RenderStep2(); break;
@@ -123,7 +124,7 @@ class DataMigrationWizardModalDialog : ModalDialog
             }
             UI::SameLine();
             vec2 currentPos = UI::GetCursorPos();
-            UI::SetCursorPos(vec2(UI::GetWindowSize().x - 90, currentPos.y));
+            UI::SetCursorPos(vec2(UI::GetWindowSize().x - 90 * scale, currentPos.y));
             if (UI::GreenButton("Migrate " + Icons::ArrowRight)) {
                 m_stage++;
             }

--- a/src/Interface/ModalDialogs/Modes/ChaosIntroduction.as
+++ b/src/Interface/ModalDialogs/Modes/ChaosIntroduction.as
@@ -13,7 +13,7 @@ class ChaosModeIntroModalDialog : ModalDialog
 
     void RenderDialog() override
     {
-        UI::BeginChild("Content", vec2(0, -32));
+        UI::BeginChild("Content", vec2(0, -32) * UI::GetScale());
         UI::PushFont(g_fontHeader);
         UI::Text("The Chaos Mode comes in the Random Map Challenge!");
         UI::PopFont();

--- a/src/Interface/ModalDialogs/Modes/RMTHelpModalDialog.as
+++ b/src/Interface/ModalDialogs/Modes/RMTHelpModalDialog.as
@@ -6,7 +6,7 @@ class RMTHelpModalDialog : ModalDialog
     RMTHelpModalDialog()
     {
         super(Icons::InfoCircle + " \\$zRandom Map Together###RMTHelp");
-        m_size = vec2(Math::Ceil(Draw::GetWidth()/1.2f), Math::Ceil(Draw::GetHeight()/1.2f));
+        m_size = vec2(Draw::GetWidth(), Draw::GetHeight()) * 0.6f;
         @clubIdTex = UI::LoadTexture("src/Assets/Images/help_clubId.png");
         @roomIdTex = UI::LoadTexture("src/Assets/Images/help_roomId.png");
     }

--- a/src/Interface/ModalDialogs/Modes/RMTHelpModalDialog.as
+++ b/src/Interface/ModalDialogs/Modes/RMTHelpModalDialog.as
@@ -13,7 +13,8 @@ class RMTHelpModalDialog : ModalDialog
 
     void RenderDialog() override
     {
-        UI::BeginChild("Content", vec2(0, -32));
+        float scale = UI::GetScale();
+        UI::BeginChild("Content", vec2(0, -32) * scale);
         UI::PushFont(g_fontHeader);
         UI::Text("Setting up a Room");
         UI::PopFont();
@@ -36,12 +37,12 @@ class RMTHelpModalDialog : ModalDialog
 
         vec2 imgSize = clubIdTex.GetSize();
         UI::Image(clubIdTex, vec2(
-            m_size.x-20,
-            imgSize.y / (imgSize.x / (m_size.x-20))
+            m_size.x-20*scale,
+            imgSize.y / (imgSize.x / (m_size.x-20*scale))
         ));
         UI::Image(roomIdTex, vec2(
-            m_size.x-20,
-            imgSize.y / (imgSize.x / (m_size.x-20))
+            m_size.x-20*scale,
+            imgSize.y / (imgSize.x / (m_size.x-20*scale))
         ));
         UI::EndChild();
         if (UI::Button(Icons::Times + " Close")) {

--- a/src/Interface/ModalDialogs/SurvivalFreeSkipWarnModalDialog.as
+++ b/src/Interface/ModalDialogs/SurvivalFreeSkipWarnModalDialog.as
@@ -13,7 +13,8 @@ class SurvivalFreeSkipWarnModalDialog : ModalDialog
 
     void RenderDialog() override
     {
-        UI::BeginChild("Content", vec2(0, -32));
+        float scale = UI::GetScale();
+        UI::BeginChild("Content", vec2(0, -32) * scale);
         UI::Text("Free skips is only if the map is impossible or broken.\n\nAre you sure to skip?");
         UI::EndChild();
         if (UI::Button(Icons::Times + " No")) {
@@ -22,7 +23,7 @@ class SurvivalFreeSkipWarnModalDialog : ModalDialog
             RMC::IsPaused = false;
         }
         UI::SameLine();
-        UI::SetCursorPos(vec2(UI::GetWindowSize().x - 70, UI::GetCursorPos().y));
+        UI::SetCursorPos(vec2(UI::GetWindowSize().x - 70 * scale, UI::GetCursorPos().y));
         if (UI::OrangeButton(Icons::PlayCircleO + " Yes")) {
             Close();
             RMC::EndTime = RMC::EndTime + (Time::get_Now() - RMC::StartTime);

--- a/src/Interface/Views/MainUI.as
+++ b/src/Interface/Views/MainUI.as
@@ -2,18 +2,19 @@ namespace MainUIView
 {
     void Header()
     {
+        float scale = UI::GetScale();
         if (MX::APIDown) {
             if (!MX::APIRefreshing) {
-                UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.20, 35));
+                UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.20, 35*scale));
                 UI::Text("\\$fc0"+Icons::ExclamationTriangle+" \\$z"+MX_NAME + " is not responding. It might be down.");
-                UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.45, 70));
+                UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.45, 70*scale));
                 if (UI::Button("Retry")) {
                     startnew(MX::FetchMapTags);
                 }
             } else {
                 int HourGlassValue = Time::Stamp % 3;
                 string Hourglass = (HourGlassValue == 0 ? Icons::HourglassStart : (HourGlassValue == 1 ? Icons::HourglassHalf : Icons::HourglassEnd));
-                UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.44, 35));
+                UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.44, 35*scale));
                 UI::TextDisabled(Hourglass + " Loading...");
             }
         } else {
@@ -21,44 +22,45 @@ namespace MainUIView
             if (Permissions::PlayLocalMap()) {
 #endif
                 if (TM::CurrentTitlePack() == "") {
-                    UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.36, 55));
+                    UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.36, 55*scale));
                     UI::Text("\\$fc0"+Icons::ExclamationTriangle+" \\$zPlease select a title pack.");
                 } else {
                     if (!MX::RandomMapIsLoading) {
-                        UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.36, 35));
+                        UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.36, 35*scale));
                         if (UI::GreenButton(Icons::Play + " Play a random map")) {
                             startnew(MX::LoadRandomMap);
                         }
                     } else {
-                        UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.42, 35));
+                        UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.42, 35*scale));
                         int HourGlassValue = Time::Stamp % 3;
                         string Hourglass = (HourGlassValue == 0 ? Icons::HourglassStart : (HourGlassValue == 1 ? Icons::HourglassHalf : Icons::HourglassEnd));
                         UI::Text(Hourglass + " Loading...");
                     }
-                    UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.34, 70));
+                    UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.34, 70*scale));
                     if (UI::ColoredButton(Icons::ClockO +" Random Map Challenge", 0.155)) {
                         window.isInRMCMode = !window.isInRMCMode;
                     }
                 }
 #if TMNEXT
             } else {
-                UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.30, 45));
+                UI::SetCursorPos(vec2(UI::GetWindowSize().x*0.30, 45*scale));
                 UI::Text(Icons::TimesCircle + " You have not the permissions to play local maps");
             }
 #endif
         }
-        UI::SetCursorPos(vec2(0, 100));
+        UI::SetCursorPos(vec2(0, 100) * scale);
         UI::Separator();
     }
 
     void RecentlyPlayedMapsTab()
     {
         if (DataJson.GetType() != Json::Type::Null && DataJson["recentlyPlayed"].Length > 0 && UI::BeginTable("RecentlyPlayedMaps", 5, UI::TableFlags::ScrollX | UI::TableFlags::NoKeepColumnsVisible)) {
+            float scale = UI::GetScale();
             UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthStretch);
             UI::TableSetupColumn("Created by", UI::TableColumnFlags::WidthStretch);
-            UI::TableSetupColumn("Played", UI::TableColumnFlags::WidthFixed, 135);
+            UI::TableSetupColumn("Played", UI::TableColumnFlags::WidthFixed, 135 * scale);
             UI::TableSetupColumn("Tags", UI::TableColumnFlags::WidthStretch);
-            UI::TableSetupColumn("Actions", UI::TableColumnFlags::WidthFixed, 90);
+            UI::TableSetupColumn("Actions", UI::TableColumnFlags::WidthFixed, 90 * scale);
             UI::TableSetupScrollFreeze(0, 1);
             UI::TableHeadersRow();
             Render::RecentlyPlayedMaps();


### PR DESCRIPTION
This adds support for UI scaling introduced in Openplanet 1.25.40.

Main UI at 125%:

![image](https://user-images.githubusercontent.com/136534/236308751-725b84e1-cd11-4694-b41b-83865f10a576.png)

Free skip dialog at 125%:

![image](https://user-images.githubusercontent.com/136534/236309139-86085811-1b59-4c45-89b4-1733b18113c6.png)

(And a bunch of other fixes in other dialogs.)