### PR TITLE
Fix issues with TMExchange api being slow on RMC

### DIFF
--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -29,6 +29,12 @@ namespace MX
 
         MX::MapInfo@ map = MX::MapInfo(res);
 
+        if (map.MapType != "TM_Race") {
+            Log::Warn("Map is not TM_Race, retrying...");
+            PreloadRandomMap();
+            return;
+        }
+
         if (map is null){
             Log::Warn("Map is null, retrying...");
             PreloadRandomMap();
@@ -125,7 +131,7 @@ namespace MX
 #endif
 
         // prevent loading non-Race maps (Royal, flagrush etc...)
-        url += "&mtype="+SUPPORTED_MAP_TYPE;
+        //url += "&mtype="+SUPPORTED_MAP_TYPE;
 
         return url;
     }


### PR DESCRIPTION
I did some testing and found out, that the TMExchange API sometimes responds very slowly or errors outright when there's too many arguments it seems like.
I have removed the "mtype=TM_Race" parameter and made it check for the map type in the plugin code itself so it wouldn't take so long to get the next random map or error when trying to get a map.