### PR TITLE
fix: remove length parameters

### DIFF
--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -92,11 +92,7 @@ namespace PluginSettings
 
     [SettingsTab name="Searching"]
     void RenderSearchingSettingTab()
-    {   
-        UI::Text("Length filter setting. Toggle this when TMX gives super long response times.");
-        UseLengthChecksInRequests = UI::Checkbox("Use length filters in API requests", UseLengthChecksInRequests);
-        UI::Separator();
-
+    {
         CustomRules = UI::Checkbox("\\$fc0"+Icons::ExclamationTriangle+" \\$zAllow search parameters in RMC. Forbidden on official Leaderboard.", CustomRules);
         UI::Separator();
 
@@ -115,6 +111,9 @@ namespace PluginSettings
 
         UI::SetNextItemWidth(160);
         // Length Operator
+        UI::Text("Length filter setting. Toggle this when TMX gives super long response times.");
+        UseLengthChecksInRequests = UI::Checkbox("Use length filters in API requests", UseLengthChecksInRequests);
+        UI::NewLine();
         if (UI::BeginCombo("##LengthOperator", MapLengthOperator)){
             for (uint i = 0; i < SearchingMapLengthOperators.Length; i++) {
                 string operator = SearchingMapLengthOperators[i];

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -70,7 +70,7 @@ namespace PluginSettings
 
     bool initArrays = false;
 
-    // add a setting that streamers can toggle to switch back to the old length checks in case the TMX API starts failing again.
+    // add a setting that people can toggle to switch between to the old length checks and manual length checks, in case the API starts failing.
     [Setting hidden]
     bool UseLengthChecksInRequests = true;
 

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -93,7 +93,7 @@ namespace PluginSettings
     [SettingsTab name="Searching"]
     void RenderSearchingSettingTab()
     {   
-        UI::Text("Length filter setting. Toggle this when: TMX gives super long response times.");
+        UI::Text("Length filter setting. Toggle this when TMX gives super long response times.");
         UseLengthChecksInRequests = UI::Checkbox("Use length filters in API requests", UseLengthChecksInRequests);
         UI::Separator();
 

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -49,7 +49,7 @@ namespace PluginSettings
         240000,
         270000,
         300000,
-        1e30,  // infinity, I guess.
+        100000000,  // infinity, I guess.
     };
 
     [Setting hidden]

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -33,6 +33,25 @@ namespace PluginSettings
         "Longer than 5 minutes"
     };
 
+    const array<int> SearchingMapLengthsMilliseconds = {
+        0,
+        15000,
+        30000,
+        45000,
+        60000,
+        75000,
+        90000,
+        105000,
+        120000,
+        150000,
+        180000,
+        210000,
+        240000,
+        270000,
+        300000,
+        1e30,  // infinity, I guess.
+    };
+
     [Setting hidden]
     string MapLength = SearchingMapLengths[0];
 
@@ -50,6 +69,10 @@ namespace PluginSettings
 #endif
 
     bool initArrays = false;
+
+    // add a setting that streamers can toggle to switch back to the old length checks in case the TMX API starts failing again.
+    [Setting hidden]
+    bool UseLengthChecksInRequests = false;
 
     [Setting hidden]
     bool TagInclusiveSearch = false;
@@ -69,7 +92,11 @@ namespace PluginSettings
 
     [SettingsTab name="Searching"]
     void RenderSearchingSettingTab()
-    {
+    {   
+
+        UseLengthChecksInRequests = UI::Checkbox("Use length filters while doing the request to TMX (toggle this if TMX response times worsen significantly)", UseLengthChecksInRequests);
+        UI::Separator();
+
         CustomRules = UI::Checkbox("\\$fc0"+Icons::ExclamationTriangle+" \\$zAllow search parameters in RMC. Forbidden on official Leaderboard.", CustomRules);
         UI::NewLine();
 

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -72,7 +72,7 @@ namespace PluginSettings
 
     // add a setting that streamers can toggle to switch back to the old length checks in case the TMX API starts failing again.
     [Setting hidden]
-    bool UseLengthChecksInRequests = false;
+    bool UseLengthChecksInRequests = true;
 
     [Setting hidden]
     bool TagInclusiveSearch = false;
@@ -93,7 +93,7 @@ namespace PluginSettings
     [SettingsTab name="Searching"]
     void RenderSearchingSettingTab()
     {   
-        UI::Text("Length filter setting. Toggle this when:\n    * TMX gives super long response times (not guaranteed to fix the issue)\n    * You are trying to play very long maps");
+        UI::Text("Length filter setting. Toggle this when: TMX gives super long response times.");
         UseLengthChecksInRequests = UI::Checkbox("Use length filters in API requests", UseLengthChecksInRequests);
         UI::Separator();
 

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -93,13 +93,11 @@ namespace PluginSettings
     [SettingsTab name="Searching"]
     void RenderSearchingSettingTab()
     {   
-
-        UseLengthChecksInRequests = UI::Checkbox("Use length filters while doing the request to TMX (toggle this if TMX response times worsen significantly)", UseLengthChecksInRequests);
+        UI::Text("Length filter setting. Toggle this when:\n    * TMX gives super long response times (not guaranteed to fix the issue)\n    * You are trying to play very long maps");
+        UseLengthChecksInRequests = UI::Checkbox("Use length filters in API requests", UseLengthChecksInRequests);
         UI::Separator();
 
         CustomRules = UI::Checkbox("\\$fc0"+Icons::ExclamationTriangle+" \\$zAllow search parameters in RMC. Forbidden on official Leaderboard.", CustomRules);
-        UI::NewLine();
-
         UI::Separator();
 
         if (UI::OrangeButton("Reset to default")){

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -37,7 +37,7 @@ namespace MX
 
         if (!PluginSettings::UseLengthChecksInRequests) {
             if ((RMC::IsRunning || RMC::IsStarting) && !PluginSettings::CustomRules) {
-                if (map.AuthorTime >= 180000) {
+                if (map.AuthorTime > 180000) {
                     Log::Warn("Map is too long, retrying...");
                     PreloadRandomMap();
                     return;

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -37,7 +37,10 @@ namespace MX
 
         if (!PluginSettings::UseLengthChecksInRequests) {
             if ((RMC::IsRunning || RMC::IsStarting) && !PluginSettings::CustomRules) {
-                if (map.AuthorTime > 180000) {
+                if (!(
+                    map.LengthName == "15 secs" || map.LengthName == "30 secs" || map.LengthName == "45 secs" || map.LengthName == "1 min" || map.LengthName == "1 m 15 s" || 
+                    map.LengthName == "1 m 30 s" || map.LengthName == "1 m 45 s" || map.LengthName == "2 min" || map.LengthName == "2 m 30 s" || map.LengthName == "3 min"
+                )) {
                     Log::Warn("Map is too long, retrying...");
                     PreloadRandomMap();
                     return;
@@ -121,7 +124,7 @@ namespace MX
                 }
             }
         }
-
+        print(map.LengthName);
         isLoadingPreload = false;
         @preloadedMap = map;
     }

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -37,10 +37,7 @@ namespace MX
 
         if (!PluginSettings::UseLengthChecksInRequests) {
             if ((RMC::IsRunning || RMC::IsStarting) && !PluginSettings::CustomRules) {
-                if (!(
-                    map.LengthName == "15 secs" || map.LengthName == "30 secs" || map.LengthName == "45 secs" || map.LengthName == "1 min" || map.LengthName == "1 m 15 s" || 
-                    map.LengthName == "1 m 30 s" || map.LengthName == "1 m 45 s" || map.LengthName == "2 min" || map.LengthName == "2 m 30 s" || map.LengthName == "3 min"
-                )) {
+                if (RMC::allowedMapLengths.Find(map.LengthName) == -1) {
                     Log::Warn("Map is too long, retrying...");
                     PreloadRandomMap();
                     return;

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -46,7 +46,7 @@ namespace MX
                 int requiredLength = PluginSettings::SearchingMapLengthsMilliseconds[PluginSettings::SearchingMapLengths.Find(PluginSettings::MapLength)];
                 switch (PluginSettings::SearchingMapLengthOperators.Find(PluginSettings::MapLengthOperator)) {
                     case 0:  // exact is prorbably a bit too strict so we'll allow a 5 second difference
-                        if (requiredLength == 1e30) {
+                        if (requiredLength == 100000000) {
                             if (map.AuthorTime <= 300000+10000) {
                                 Log::Warn("Map is too short, retrying...");
                                 PreloadRandomMap();
@@ -62,7 +62,7 @@ namespace MX
                         break;
                     
                     case 1:
-                        if (requiredLength == 1e30) {
+                        if (requiredLength == 100000000) {
                             if (map.AuthorTime > 300000) {
                                 Log::Warn("Map is too long, retrying...");
                                 PreloadRandomMap();
@@ -78,7 +78,7 @@ namespace MX
                         break;
                     
                     case 2:
-                        if (requiredLength == 1e30) {
+                        if (requiredLength == 100000000) {
                             if (map.AuthorTime < 300000+10000) {
                                 Log::Warn("Map is too short, retrying...");
                                 PreloadRandomMap();
@@ -94,7 +94,7 @@ namespace MX
                         break;
                      
                     case 3:
-                        if (requiredLength == 1e30) {
+                        if (requiredLength == 100000000) {
                             // everything is shorter than long, do nothing
                         } else if (!(map.AuthorTime <= requiredLength)) {
                             Log::Warn("Map is not the correct length, retrying...");
@@ -104,7 +104,7 @@ namespace MX
                         break;
 
                     case 4:
-                        if (requiredLength == 1e30) {
+                        if (requiredLength == 100000000) {
                             if (map.AuthorTime <= 300000) {
                                 Log::Warn("Map is too long, retrying...");
                                 PreloadRandomMap();

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -48,16 +48,16 @@ namespace MX
             } else if (PluginSettings::MapLength != "Anything") {
                 int requiredLength = PluginSettings::SearchingMapLengthsMilliseconds[PluginSettings::SearchingMapLengths.Find(PluginSettings::MapLength)];
                 switch (PluginSettings::SearchingMapLengthOperators.Find(PluginSettings::MapLengthOperator)) {
-                    case 0:  // exact is prorbably a bit too strict so we'll allow a 5 second difference
+                    case 0:  // exact is prorbably a bit too strict so we'll allow an about 15 seconds difference
                         if (requiredLength == 100000000) {
-                            if (map.AuthorTime <= 300000+10000) {
+                            if (map.AuthorTime <= 300000+15000) {
                                 Log::Warn("Map is too short, retrying...");
                                 PreloadRandomMap();
                                 return;
                             } else {
                                 break;
                             }
-                        } else if ((map.AuthorTime < requiredLength-5000) || (map.AuthorTime > requiredLength+5000)) {
+                        } else if ((map.AuthorTime < requiredLength-15000) || (map.AuthorTime > requiredLength+15000)) {
                             Log::Warn("Map is not the correct length, retrying...");
                             PreloadRandomMap();
                             return;

--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -21,6 +21,19 @@ namespace RMC
         "Author"
     };
 
+    const array<string> allowedMapLengths = {
+        "15 secs",
+        "30 secs",
+        "45 secs",
+        "1 min",
+        "1 m 15 s",
+        "1 m 30 s",
+        "1 m 45 s",
+        "2 min", 
+        "2 m 30 s", 
+        "3 min"
+    };
+
     RMC@ Challenge;
     RMS@ Survival;
     RMObjective@ Objective;


### PR DESCRIPTION
This allows you to disable the usage of length query parameters in API requests. This offers a partial fix for #68.

Ideally this also completely fixes the timeout issues, but I'm not sure if making query parameters opt-in immediately is the best thing to do.