### PR TITLE
feat: change query parameters on API errors

### DIFF
--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -12,8 +12,10 @@ namespace MX
             res = API::GetAsync(URL)["results"][0];
         } catch {
             Log::Error("ManiaExchange API returned an error, retrying...");
-            RMC::config.length = RMC::config.length == "9" ? "8" : "9"
-            RMC::config.lengthop = RMC::config.lengthop == "1" ? "3" : "1"
+            if (RMC::IsRunning || RMC::IsStarting) {
+                RMC::config.length = RMC::config.length == "9" ? "8" : "9";
+                RMC::config.lengthop = RMC::config.lengthop == "1" ? "3" : "1";
+            }
             PreloadRandomMap();
             return;
         }

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -12,6 +12,8 @@ namespace MX
             res = API::GetAsync(URL)["results"][0];
         } catch {
             Log::Error("ManiaExchange API returned an error, retrying...");
+            RMC::config.length = RMC::config.length == "9" ? "8" : "9"
+            RMC::config.lengthop = RMC::config.lengthop == "1" ? "3" : "1"
             PreloadRandomMap();
             return;
         }


### PR DESCRIPTION
This automatically changes the query parameters from 1&9 to 3&8 every time the API returns an error with the hope to mitigate the issues with the API blocking requests to specific query parameters after some time.

This hopefully offers a partial fix for #68.