### PR TITLE
fix: remove preloaded map on new challenge start

### DIFF
--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -95,6 +95,9 @@ namespace RMC
         ShowTimer = true;
         IsStarting = true;
         ClickedOnSkip = false;
+        if (!(MX::preloadedMap is null)) {
+            MX::preloadedMap = null;
+        }
         MX::LoadRandomMap();
         while (!TM::IsMapLoaded()){
             sleep(100);


### PR DESCRIPTION
This is necessary as a map could have been preloaded from a previous run with custom parameters. If you start a leaderboard run after and a map with custom parameters still is preloaded the run would be invalid. So it is best to load new maps on every newly started run.