### PR TITLE
fix: Add skip failure information for RMT skips

### DIFF
--- a/src/Utils/RMC/RMT.as
+++ b/src/Utils/RMC/RMT.as
@@ -429,6 +429,7 @@ class RMT : RMC
 #endif
             startnew(CoroutineFunc(RMTSwitchMap));
         }
+        Log::Warn("Skip might fail due to Nadeo. If it fails, try vote-skipping, it should skip properly.");
         UI::EndDisabled();
     }
 


### PR DESCRIPTION
resolves #83 