### PR TITLE
Add ability to proxy trackmania api to another url

### DIFF
--- a/src/Exports/ExportsCode.as
+++ b/src/Exports/ExportsCode.as
@@ -24,6 +24,6 @@ namespace MXRandom
         playedAt["Second"] = date.Second;
         res["PlayedAt"] = playedAt;
         MX::MapInfo@ map = MX::MapInfo(res);
-        return "https://"+MX_URL+"/maps/download/"+map.TrackID;
+        return PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID;
     }
 }

--- a/src/Interface/Renders/RecentlyMapsList.as
+++ b/src/Interface/Renders/RecentlyMapsList.as
@@ -45,7 +45,7 @@ namespace Render
 #else
                 if (TM::CurrentTitlePack() == map.TitlePack && UI::GreenButton(Icons::Play)) {
 #endif
-                    TM::loadMapURL = "https://"+MX_URL+"/maps/download/"+map.TrackID;
+                    TM::loadMapURL = PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID;
                     startnew(TM::LoadMap);
                 }
 

--- a/src/Settings/About.as
+++ b/src/Settings/About.as
@@ -64,8 +64,7 @@ void RenderAboutTab()
     UI::SameLine();
     if (UI::RedButton(Icons::Heart + " \\$zSupport ManiaExchange")) OpenBrowserURL("https://"+MX_URL+"/support");
 
-    UI::Text("Base URL \\$777" + MX_URL);
-    if (PluginSettings::RMC_MX_Url != "https://"+MX_URL) UI::Text("Proxy URL \\$777" + PluginSettings::RMC_MX_Url);
+    UI::Text("Base URL \\$777" + PluginSettings::RMC_MX_Url);
 
     UI::AlignTextToFramePadding();
     UI::Text("Follow the ManiaExchange network on");

--- a/src/Settings/About.as
+++ b/src/Settings/About.as
@@ -65,6 +65,7 @@ void RenderAboutTab()
     if (UI::RedButton(Icons::Heart + " \\$zSupport ManiaExchange")) OpenBrowserURL("https://"+MX_URL+"/support");
 
     UI::Text("Base URL \\$777" + MX_URL);
+    if (PluginSettings::RMC_MX_Url != "https://"+MX_URL) UI::Text("Proxy URL \\$777" + PluginSettings::RMC_MX_Url);
 
     UI::AlignTextToFramePadding();
     UI::Text("Follow the ManiaExchange network on");

--- a/src/Settings/RMCParameters.as
+++ b/src/Settings/RMCParameters.as
@@ -114,8 +114,8 @@ namespace PluginSettings
 #endif
 
             UI::SetNextItemWidth(300);
-            RMC_MX_Url = UI::InputText("ManiaExchange Proxy Url", RMC_MX_Url);
-            UI::SetPreviousTooltip("Proxy api calls to ManiaExchange via this url. Useful for caching and preloading api responses for better performance.");
+            RMC_MX_Url = UI::InputText("ManiaExchange Base Url", RMC_MX_Url);
+            UI::SetPreviousTooltip("Use this url for api calls to ManiaExchange. Useful for hosting your own service for caching and preloading api responses for better performance.");
 
             UI::EndTabItem();
         }

--- a/src/Settings/RMCParameters.as
+++ b/src/Settings/RMCParameters.as
@@ -61,6 +61,9 @@ namespace PluginSettings
     [Setting hidden]
     int RMC_Together_RoomId = 0;
 
+    [Setting hidden]
+    string RMC_MX_Url = "https://" + MX_URL;
+
     [SettingsTab name="Random Map Challenge"]
     void RenderRMCSettingTab(bool dontShowBaseInfos = false)
     {
@@ -80,6 +83,7 @@ namespace PluginSettings
                 RMC_Duration = 60;
                 RMC_SurvivalMaxTime = 15;
                 RMC_PrepatchTagsWarns = true;
+                RMC_MX_Url = "https://" + MX_URL;
             }
             if (UI::BeginCombo("Goal", RMC_GoalMedal)){
                 for (uint i = 0; i < RMC::Medals.Length; i++) {
@@ -108,6 +112,11 @@ namespace PluginSettings
             RMC_PrepatchTagsWarns = UI::Checkbox("Prepatch maps warnings", RMC_PrepatchTagsWarns);
             UI::SetPreviousTooltip("Display a warning if the map is built before the new physics patches (eg the bobsleigh update)");
 #endif
+
+            UI::SetNextItemWidth(300);
+            RMC_MX_Url = UI::InputText("ManiaExchange Proxy Url", RMC_MX_Url);
+            UI::SetPreviousTooltip("Proxy api calls to ManiaExchange via this url. Useful for caching and preloading api responses for better performance.");
+
             UI::EndTabItem();
         }
 

--- a/src/Utils/MX/Methods/DownloadMap.as
+++ b/src/Utils/MX/Methods/DownloadMap.as
@@ -2,7 +2,7 @@ namespace MX
 {
     void DownloadMap(const int &in mapId, string fileName = "") {
         try {
-            auto json = API::GetAsync("https://"+MX_URL+"/api/maps/get_map_info/multi/"+mapId);
+            auto json = API::GetAsync(PluginSettings::RMC_MX_Url+"/api/maps/get_map_info/multi/"+mapId);
             if (json.Length == 0) {
                 Log::Error("Track not found.", true);
                 return;
@@ -14,7 +14,7 @@ namespace MX
             if (!IO::FolderExists(downloadedMapFolder)) IO::CreateFolder(downloadedMapFolder);
             if (!IO::FolderExists(mxDLFolder)) IO::CreateFolder(mxDLFolder);
 
-            Net::HttpRequest@ netMap = API::Get("https://"+MX_URL+"/maps/download/"+mapId);
+            Net::HttpRequest@ netMap = API::Get(PluginSettings::RMC_MX_Url+"/maps/download/"+mapId);
             Log::Trace("Started downloading map "+map.Name+" ("+mapId+") to "+mxDLFolder);
             while(!netMap.Finished()) {
                 yield();

--- a/src/Utils/MX/Methods/FetchMapTags.as
+++ b/src/Utils/MX/Methods/FetchMapTags.as
@@ -5,7 +5,7 @@ namespace MX
         m_mapTags.RemoveRange(0, m_mapTags.Length);
         APIRefreshing = true;
 
-        Json::Value resNet = API::GetAsync("https://"+MX_URL+"/api/tags/gettags");
+        Json::Value resNet = API::GetAsync(PluginSettings::RMC_MX_Url+"/api/tags/gettags");
 
         try {
             for (uint i = 0; i < resNet.get_Length(); i++)

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -6,7 +6,7 @@ namespace MX
     Json::Value CheckCustomRulesParametersNoResults() {
         // for some reason if we use random it *always* returns a webpage instead of an actual dict response if no items are found. It also sometimes does not find any items even though there are some.
         // So we have to use a non-random API call which then gives us a dict from which we can check if any item would exist with the specified parameters.
-        string check_url = "https://trackmania.exchange/mapsearch2/search?api=on&limit=1";
+        string check_url = PluginSettings::RMC_MX_Url + "/mapsearch2/search?api=on&limit=1";
 #if TMNEXT
         // ignore CharacterPilot maps
         check_url += "&vehicles=1";
@@ -237,10 +237,10 @@ namespace MX
 #if DEPENDENCY_CHAOSMODE
             if (ChaosMode::IsInRMCMode()) {
                 Log::Trace("Loading map in Chaos Mode");
-                app.ManiaTitleControlScriptAPI.PlayMap("https://"+MX_URL+"/maps/download/"+map.TrackID, "TrackMania/ChaosModeRMC", "");
+                app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID, "TrackMania/ChaosModeRMC", "");
             } else
 #endif
-            app.ManiaTitleControlScriptAPI.PlayMap("https://"+MX_URL+"/maps/download/"+map.TrackID, "", "");
+            app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID, "", "");
         }
         catch
         {
@@ -253,7 +253,7 @@ namespace MX
 
     string CreateQueryURL()
     {
-        string url = "https://"+MX_URL+"/mapsearch2/search?api=on&random=1";
+        string url = PluginSettings::RMC_MX_Url+"/mapsearch2/search?api=on&random=1";
 
         if ((RMC::IsRunning || RMC::IsStarting) && !PluginSettings::CustomRules)
         {

--- a/src/Utils/Migration.as
+++ b/src/Utils/Migration.as
@@ -22,7 +22,7 @@ namespace Migration
     void StartRequestMapsInfo(array<int> MXIds)
     {
         array<MX::MapInfo@> Maps;
-        string url = "https://"+MX_URL+"/api/maps/get_map_info/multi/";
+        string url = PluginSettings::RMC_MX_Url+"/api/maps/get_map_info/multi/";
         string mapIdsStr = "";
 
         for (uint i = 0; i < MXIds.Length; i++)


### PR DESCRIPTION
This will make it possible to run tests against a local simulator/mock for the MX api, but additionally make it so users of the plugin can stand up their own proxy api server to serve preloaded and cached api response data from the MX api. This will allow users to be not as dependent on the uptime and reliability of the MX api when doing RMC/S runs.

I debated putting this under the search settings, but since those seemed to be opting into a custom ruleset that additionally invalidates being on the official leaderboard, this didnt really seem like a great fit. Ofc, allowing ANY proxies to be included here, does mean someone could circumvent "randomness" by mocking responses for maps they are already familiar with OR find easier looking maps to essentially cheat official leaderboards... so maybe it makes sense to be in that section ultimately. If it makes it easier to move it under that section to get this merged, I can happily do that for now.

It would be nice if you could use this feature and not be opted out of official leaderboards, but I think then you'd need to vet some "allowed" proxy services that prove to be inline with the official rules of the leaderboard.

Really just opening this to start the discussion, as ultimately testing the plugin entirely is sort of out of my wheelhouse (I don't see any automated tests and I am not intimately familiar with all provided functionality of the plugin or even openplanet plugin development for that matter).