### PR TITLE
feat: check for exact map author

### DIFF
--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -52,11 +52,16 @@ namespace PluginSettings
         100000000,  // infinity, I guess.
     };
 
+    array<string> MapAuthorNamesArr = {};
+
     [Setting hidden]
     string MapLength = SearchingMapLengths[0];
 
     [Setting hidden]
     string MapAuthor = "";
+
+    [Setting hidden]
+    bool MapAuthorNameNeedsExactMatch = true;
 
     [Setting hidden]
     string MapName = "";
@@ -113,6 +118,8 @@ namespace PluginSettings
             MapName = "";
             MapPackID = 0;
             MapTagsArr = {};
+            MapAuthorNamesArr = {};
+            MapAuthorNameNeedsExactMatch = true;
 #if TMNEXT
             ExcludeMapTagsArr = {23, 37, 40};
 #else
@@ -166,12 +173,15 @@ namespace PluginSettings
         // Using InputText instead of a InputInt because it looks better and using "" as empty value instead of 0 for consistency with the other fields
         UI::SetNextItemWidth(200);
         MapAuthor = UI::InputText("Map Author(s) Filter", MapAuthor, false);
-
+        UI::SameLine();
+        MapAuthorNameNeedsExactMatch = UI::Checkbox("Exact name matches", MapAuthorNameNeedsExactMatch);
+        UI::SetPreviousTooltip("If disabled, you will get results for any author that contains the text you entered.\nIf you search for \"Nadeo\", you will get results for \"Nadeo\", \"Nadeo123\", \"Nadeo_\", etc.\nIf enabled, you will only get results for \"Nadeo\".\nHowever this can lead to issues if the author has changed their MX username since uploading the map. This can be avoided by specifying all the names the author has used.");
         UI::NewLine();
 
         if (!initArrays) {
             MapTagsArr = ConvertListToArray(MapTags);
             ExcludeMapTagsArr = ConvertListToArray(ExcludeMapTags);
+            MapAuthorNamesArr = ConvertStringToArray(MapAuthor);
             initArrays = true;
         }
 
@@ -259,6 +269,14 @@ namespace PluginSettings
             tags = tags.SubStr(i + 1);
         }
         if (tags != "") res.InsertLast(Text::ParseInt(tags));
+        return res;
+    }
+
+    array<string> ConvertStringToArray(string str, string separator = ",") {
+        array<string> res = str.Split(separator);
+        for (uint i = 0; i < res.Length; i++) {
+            res[i] = res[i].ToLower();  // It does not look like TMX considers case when searching for author names, so we can just use lowercase
+        }
         return res;
     }
 

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -178,10 +178,12 @@ namespace PluginSettings
         UI::SetPreviousTooltip("If disabled, you will get results for any author that contains the text you entered.\nIf you search for \"Nadeo\", you will get results for \"Nadeo\", \"Nadeo123\", \"Nadeo_\", etc.\nIf enabled, you will only get results for \"Nadeo\".\nHowever this can lead to issues if the author has changed their MX username since uploading the map. This can be avoided by specifying all the names the author has used.");
         UI::NewLine();
 
+        MapAuthorNamesArr = ConvertStringToArray(MapAuthor);
+
+
         if (!initArrays) {
             MapTagsArr = ConvertListToArray(MapTags);
             ExcludeMapTagsArr = ConvertListToArray(ExcludeMapTags);
-            MapAuthorNamesArr = ConvertStringToArray(MapAuthor);
             initArrays = true;
         }
 

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -114,6 +114,19 @@ namespace MX
             return;
         }
 
+        if (
+            (((RMC::IsRunning || RMC::IsStarting) && PluginSettings::CustomRules && PluginSettings::MapAuthorNameNeedsExactMatch) 
+            || (!RMC::IsRunning && !RMC::IsStarting && PluginSettings::MapAuthorNameNeedsExactMatch)) && PluginSettings::MapAuthor != ""
+        ) {
+            string author = map.Username.ToLower();
+            print(PluginSettings::MapAuthorNamesArr.Find(author));
+            if (PluginSettings::MapAuthorNamesArr.Find(author) == -1) {
+                Log::Warn("Map author does not match, retrying...");
+                PreloadRandomMap();
+                return;
+            }
+        }
+
         if (!PluginSettings::UseLengthChecksInRequests) {
             if ((RMC::IsRunning || RMC::IsStarting) && !PluginSettings::CustomRules) {
                 if (RMC::allowedMapLengths.Find(map.LengthName) == -1) {


### PR DESCRIPTION
The TMX API only checks if the author name specified in the request is *in* the map so this adds a setting that ensures the specified author matches the map author exactly.