### PR TITLE
RMT: Update room with 1 request not 2, fix race condition while changing maps

### DIFF
--- a/src/Utils/RMC/RMT.as
+++ b/src/Utils/RMC/RMT.as
@@ -130,8 +130,7 @@ class RMT : RMC
         }
 
         DataManager::SaveMapToRecentlyPlayed(currentMap);
-        MXNadeoServicesGlobal::SetMapToClubRoomAsync(RMTRoom, currentMap.TrackUID);
-        MXNadeoServicesGlobal::ClubRoomSwitchMapAsync(RMTRoom);
+        MXNadeoServicesGlobal::ClubRoomSetMapAndSwitchAsync(RMTRoom, currentMap.TrackUID);
         while (!TM::IsMapCorrect(currentMap.TrackUID)) sleep(1000);
         MXNadeoServicesGlobal::ClubRoomSetCountdownTimer(RMTRoom, TimeLimit() / 1000);
         while (GetApp().CurrentPlayground is null) yield();
@@ -205,8 +204,7 @@ class RMT : RMC
         UI::ShowNotification(Icons::InfoCircle + " RMT - Information on map switching", "Nadeo prevent sometimes when switching map too often and will not change map.\nIf after 10 seconds the podium screen is not shown, you can start a vote to change to next map in the game pause menu.", Text::ParseHexColor("#991703"));
 
         DataManager::SaveMapToRecentlyPlayed(currentMap);
-        MXNadeoServicesGlobal::SetMapToClubRoomAsync(RMTRoom, currentMap.TrackUID);
-        MXNadeoServicesGlobal::ClubRoomSwitchMapAsync(RMTRoom);
+        MXNadeoServicesGlobal::ClubRoomSetMapAndSwitchAsync(RMTRoom, currentMap.TrackUID);
         while (!TM::IsMapCorrect(currentMap.TrackUID)) sleep(1000);
         MXNadeoServicesGlobal::ClubRoomSetCountdownTimer(RMTRoom, RMTTimerMapChange / 1000);
         while (GetApp().CurrentPlayground is null) yield();


### PR DESCRIPTION
I suspect that one of the reasons map changing is a little unreliable is because there's a race condition updating the server. Something like this:

- Request 1 is fired and received by nadeo (map list)
- Server processes update and sends an async msg to the game server to update settings / download map / etc
- Server returns status 200
- Request 2 is fired and received (update timer)
- At this point, the game server hasn't been updated -- maybe the map is still downloading
- Server constructs update payload that ends up using old cached info / map list, sends async msg to game server
- Game server gets the update timer payload, and then either ignores the map update or the map update gets overriden by the update timer. 

An alternate solution would be to watch the list of maps and wait for that to update before firing the update timer request.

I ran through a lot of map changes yesterday and didn't have a problem using this method, but haven't tested it extensively. I don't think it's any worse than the current implementation, though (i.e., I don't think it'll introduce any new issues even if it doesn't work to fix the map change bug)