### PR TITLE
fix: dont rely on tmx when loading a save

### DIFF
--- a/src/Utils/DataManager.as
+++ b/src/Utils/DataManager.as
@@ -37,7 +37,7 @@ namespace DataManager
         string gameMode = "RM" + lastLetter;
         Json::Value SaveFileData = Json::Object();
         SaveFileData["TimerRemaining"] = 0;
-        SaveFileData["MapID"] = 0;
+        SaveFileData["MapData"] = 0;
         SaveFileData["TimeSpentOnMap"] = 0;  // this is updated when you manually quit on a map
         SaveFileData["PrimaryCounterValue"] = 0;  // Amount of goal medals
         SaveFileData["SecondaryCounterValue"] = 0;  // Second medal type for RMC ("Gold Skips") or skip count for RMS

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -228,12 +228,7 @@ namespace MX
             RandomMapIsLoading = true;
             MX::MapInfo@ map;
             if (RMC::ContinueSavedRun && !RMC::IsInited) {
-#if TMNEXT
-                string url = "https://trackmania.exchange/api/maps/get_map_info/id/" + tostring(RMC::CurrentMapID);
-#else
-                string url = MX_URL + "/api/maps/get_map_info/id/" + tostring(RMC::CurrentMapID);
-#endif
-                Json::Value res = API::GetAsync(url);
+                Json::Value res = RMC::CurrentMapJsonData;
                 Json::Value playedAt = Json::Object();
                 Time::Info date = Time::Parse();
                 playedAt["Year"] = date.Year;
@@ -276,7 +271,7 @@ namespace MX
             } else
 #endif
             app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID, "", "");
-            RMC::CurrentMapID = map.TrackID;
+            RMC::CurrentMapJsonData = map.ToJson();
         }
         catch
         {

--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -12,7 +12,7 @@ namespace RMC
     int EndTime = -1;
     int TimeSpentMap = -1;
     int TimeSpawnedMap = -1;
-    int CurrentMapID = 0;
+    Json::Value CurrentMapJsonData = Json::Object();
     bool ContinueSavedRun = false;
     bool IsInited = false;
     bool HasCompletedCheckbox = false;
@@ -117,7 +117,7 @@ namespace RMC
             }
         }
         if (RMC::ContinueSavedRun) {
-            RMC::CurrentMapID = CurrentRunData["MapID"];
+            RMC::CurrentMapJsonData = CurrentRunData["MapData"];
         }
         if (!(MX::preloadedMap is null)) {
             @MX::preloadedMap = null;
@@ -257,8 +257,7 @@ namespace RMC
         TimeSpawnedMap = Time::Now;
         ClickedOnSkip = false;
 
-        // TODO add back autosaves
-        CurrentRunData["MapID"] = CurrentMapID;
+        CurrentRunData["MapData"] = CurrentMapJsonData;
         CurrentRunData["TimeSpentOnMap"] = 0;
         CurrentRunData["PrimaryCounterValue"] = GoalMedalCount;
         CurrentRunData["SecondaryCounterValue"] = selectedGameMode == GameMode::Challenge ? Challenge.BelowMedalCount : Survival.Skips;
@@ -271,7 +270,7 @@ namespace RMC
         MX::PreloadRandomMap();
     }
     void SaveRunDataOnEnd() {
-        RMC::CurrentRunData["MapID"] = RMC::CurrentMapID;
+        RMC::CurrentRunData["MapData"] = RMC::CurrentMapJsonData;
         RMC::CurrentRunData["TimerRemaining"] = RMC::EndTimeCopyForSaveData - RMC::StartTimeCopyForSaveData;
         RMC::CurrentRunData["TimeSpentOnMap"] = RMC::TimeSpentMap;
         RMC::CurrentRunData["PrimaryCounterValue"] = RMC::GoalMedalCount;


### PR DESCRIPTION
This removes the forced TMX API request by saving a copy of the relevant map data when saving, so that you can load runs even when TMX is completely down.

Note: as saving runs is an unreleased change there is no need to check for the old "mapID" key.