### PR TITLE
Makes MP4 use the SingleMap gamemode instead of the engine fallback

### DIFF
--- a/src/Constants.as
+++ b/src/Constants.as
@@ -6,6 +6,7 @@ const string MX_COLOR_STR               = "\\$39f";
 const vec4   MX_COLOR_VEC               = vec4(0.2, 0.6, 1, 1);
 const string MX_URL                     = "tm.mania.exchange";
 const string SUPPORTED_MAP_TYPE         = "Race";
+const string DEFAULT_MODE               = "SingleMap";
 
 #elif TMNEXT
 
@@ -15,6 +16,7 @@ const string MX_COLOR_STR               = "\\$9fc";
 const vec4   MX_COLOR_VEC               = vec4(0.3, 0.7, 0.4, 1);
 const string MX_URL                     = "trackmania.exchange";
 const string SUPPORTED_MAP_TYPE         = "TM_Race";
+const string DEFAULT_MODE               = "";
 #endif
 
 const string PLUGIN_NAME                = MX_NAME + " Random Map Picker";

--- a/src/Utils/Game/Methods.as
+++ b/src/Utils/Game/Methods.as
@@ -8,7 +8,7 @@ namespace TM
         while(!app.ManiaTitleControlScriptAPI.IsReady) {
             yield(); // Wait until the ManiaTitleControlScriptAPI is ready for loading the next map
         }
-        app.ManiaTitleControlScriptAPI.PlayMap(loadMapURL, "", "");
+        app.ManiaTitleControlScriptAPI.PlayMap(loadMapURL, DEFAULT_MODE, "");
     }
 
     bool IsMapLoaded(){

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -270,7 +270,7 @@ namespace MX
                 app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID, "TrackMania/ChaosModeRMC", "");
             } else
 #endif
-            app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID, "", "");
+            app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID, DEFAULT_MODE, "");
             RMC::CurrentMapJsonData = map.ToJson();
         }
         catch


### PR DESCRIPTION
Title! Currently, both this and the ManiaExchange menu are a bit odd in their behavior in MP4. Notably, when launching a map, you're immediately faced with MP3's UI, among other oddities. This is because the plugin isn't loading any gamemode at all, instead relying on the engine's fallback gamemode.

So this PR is incredibly straight-forward: it makes the plugin's maploading load the gamemode that Nadeo's maniascript generally tries to enforce as a default, that gamemode being `SingleMap`. This applies only for MP4, and leaves TM2020 untouched (in theory at least; we can't test that for certain)

This makes loading a map through the plugin behave exactly as a map loaded through the game's menus would behave, as one would naturally expect a plugin like this to achieve.