### PR TITLE
refactor: improve (auto)saving system

### DIFF
--- a/src/Interface/ModalDialogs/SaveRunQuestionModalDialog.as
+++ b/src/Interface/ModalDialogs/SaveRunQuestionModalDialog.as
@@ -20,7 +20,7 @@ class SaveRunQuestionModalDialog : ModalDialog
         UI::SetCursorPos(vec2(UI::GetWindowSize().x - 70 * scale, UI::GetCursorPos().y));
         if (UI::OrangeButton(Icons::PlayCircleO + " Yes")) {
             Close();
-            RMC::SaveRunDataOnEnd();
+            RMC::CreateSave(true);
             Log::Log("Saved run data", true);
         }
     }

--- a/src/Utils/DataManager.as
+++ b/src/Utils/DataManager.as
@@ -36,8 +36,9 @@ namespace DataManager
         string lastLetter = tostring(RMC::selectedGameMode).SubStr(0,1);
         string gameMode = "RM" + lastLetter;
         Json::Value SaveFileData = Json::Object();
+        SaveFileData["PBOnMap"] = -1;
         SaveFileData["TimerRemaining"] = 0;
-        SaveFileData["MapData"] = 0;
+        SaveFileData["MapData"] = Json::Object();
         SaveFileData["TimeSpentOnMap"] = 0;  // this is updated when you manually quit on a map
         SaveFileData["PrimaryCounterValue"] = 0;  // Amount of goal medals
         SaveFileData["SecondaryCounterValue"] = 0;  // Second medal type for RMC ("Gold Skips") or skip count for RMS

--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -240,7 +240,7 @@ namespace RMC
                     Log::Trace("Medal: " + medal);
                 }
 
-                if (CurrentTimeOnMap != time) {
+                if (CurrentTimeOnMap > time) {
                     // PB
                     CurrentTimeOnMap = time;
                     CreateSave();

--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -262,7 +262,7 @@ namespace RMC
         CurrentRunData["PrimaryCounterValue"] = GoalMedalCount;
         CurrentRunData["SecondaryCounterValue"] = selectedGameMode == GameMode::Challenge ? Challenge.BelowMedalCount : Survival.Skips;
         CurrentRunData["CurrentRunTime"] = selectedGameMode == GameMode::Survival ? Survival.SurvivedTime : Challenge.ModeStartTimestamp;
-        CurrentRunData["TimerRemaining"] = RMC::EndTimeCopyForSaveData - RMC::StartTimeCopyForSaveData;
+        CurrentRunData["TimerRemaining"] = RMC::EndTime - RMC::StartTime;  // don't use the copies here, they are only updated for game end.
         CurrentRunData["GotGoalMedalOnMap"] = false;
         CurrentRunData["GotBelowMedalOnMap"] = false;
         DataManager::SaveCurrentRunData();

--- a/src/Utils/RMC/RMC.as
+++ b/src/Utils/RMC/RMC.as
@@ -52,7 +52,7 @@ class RMC
                         // sleeping here to wait for the dialog to be closed crashes the plugin, hence we just have a copy
                         // of the timers to use for the save file
                     } else {
-                        RMC::SaveRunDataOnEnd();
+                        RMC::CreateSave(true);
                         vec4 color = UI::HSV(0.25, 1, 0.7);
                         UI::ShowNotification(PLUGIN_NAME, "Saved the state of the current run", color, 5000);
                     }
@@ -327,6 +327,9 @@ class RMC
         }
         RMC::IsPaused = false;
         RMC::IsRunning = true;
+        if (RMC::GotBelowMedalOnCurrentMap && RMC::GotGoalMedalOnCurrentMap) RMC::GotBelowMedalOnCurrentMap = false;
+        if (RMC::GotBelowMedalOnCurrentMap) GotBelowGoalMedalNotification();
+        if (RMC::GotGoalMedalOnCurrentMap) GotGoalMedalNotification();
         startnew(CoroutineFunc(TimerYield));
     }
 
@@ -424,6 +427,7 @@ class RMC
                 GotGoalMedalNotification();
                 RMC::GoalMedalCount += 1;
                 RMC::GotGoalMedalOnCurrentMap = true;
+                RMC::CreateSave();
             }
             if (
                 RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal)-1 &&
@@ -432,6 +436,7 @@ class RMC
             {
                 GotBelowGoalMedalNotification();
                 RMC::GotBelowMedalOnCurrentMap = true;
+                RMC::CreateSave();
             }
         }
     }

--- a/src/Utils/RMC/RMS.as
+++ b/src/Utils/RMC/RMS.as
@@ -95,6 +95,7 @@ class RMS : RMC
         SurvivedTimeStart = !RMC::ContinueSavedRun ? Time::get_Now() : Time::get_Now() - int(RMC::CurrentRunData["CurrentRunTime"]);
         RMC::IsPaused = false;
         RMC::IsRunning = true;
+        if (RMC::GotGoalMedalOnCurrentMap) GotGoalMedalNotification();
         startnew(CoroutineFunc(TimerYield));
     }
 


### PR DESCRIPTION
fixes issues regarding autosaves and combines autosaves and normal saves into one function.

fixed:
- issue where the autosave value for "timer remaining" would always be 0 ``(-1 - (-1))`` because of the wrong variable used. This renders autosaves unusable (the save is created, but not considered as the remaining time is 0). 
- issue where a broken map could save as the last played map in the autosave, making the run unusable as the save file destroys when the run is loaded but the game crashes again due to the map being broken

changed:
- combined save & autosave into one function as only one variable differs.
- Autosaves now happen on every PB instead of when the map changes.

A quick new release for this would be appreciated, as currently runs are not continuable if the game crashes, [see Scrapie's stream, for example](https://www.twitch.tv/videos/1931323038?t=00h47m27s).