### PR TITLE
refactor: imrpove Skip Buttons for RMC and RMS

### DIFF
--- a/src/Interface/ModalDialogs/BrokenMapSkipWarnModalDialog.as
+++ b/src/Interface/ModalDialogs/BrokenMapSkipWarnModalDialog.as
@@ -1,13 +1,13 @@
-class SurvivalFreeSkipWarnModalDialog : ModalDialog
+class BrokenMapSkipWarnModalDialog : ModalDialog
 {
     Net::HttpRequest@ m_request;
     string resErrorString;
     Json::Value m_rulesJson;
     bool m_requestError = false;
 
-    SurvivalFreeSkipWarnModalDialog()
+    BrokenMapSkipWarnModalDialog()
     {
-        super("\\$f90" + Icons::ExclamationTriangle + " \\$zWarning###RMSFreeSkip");
+        super("\\$f90" + Icons::ExclamationTriangle + " \\$zWarning###BrokenMapSkip");
         m_size = vec2(400, 130);
     }
 
@@ -15,7 +15,7 @@ class SurvivalFreeSkipWarnModalDialog : ModalDialog
     {
         float scale = UI::GetScale();
         UI::BeginChild("Content", vec2(0, -32) * scale);
-        UI::Text("Free skips is only if the map is impossible or broken.\n\nAre you sure to skip?");
+        UI::Text("Broken Map skips are only for impossible or broken maps.\n\nAre you sure to skip?");
         UI::EndChild();
         if (UI::Button(Icons::Times + " No")) {
             Close();
@@ -28,14 +28,9 @@ class SurvivalFreeSkipWarnModalDialog : ModalDialog
             Close();
             RMC::EndTime = RMC::EndTime + (Time::get_Now() - RMC::StartTime);
             RMC::IsPaused = false;
-            print("RMC: Survival Free Skip");
+            print("RMC: Broken Map Skip");
             UI::ShowNotification("Please wait...");
-            MX::MapInfo@ CurrentMapFromJson = MX::MapInfo(DataJson["recentlyPlayed"][0]);
-#if TMNEXT
-            if (PluginSettings::RMC_PrepatchTagsWarns && RMC::config.isMapHasPrepatchMapTags(CurrentMapFromJson)) {
-                RMC::EndTime += RMC::TimeSpentMap;
-            }
-#endif
+            RMC::EndTime += RMC::TimeSpentMap;
             startnew(RMC::SwitchMap);
         }
     }

--- a/src/Settings/RMCParameters.as
+++ b/src/Settings/RMCParameters.as
@@ -65,7 +65,7 @@ namespace PluginSettings
     bool RMC_RUN_AUTOSAVE = true;
 
     [Setting hidden]
-    int RMC_FreeSkipAMount = 1;  // one free skip as per official rules
+    int RMC_FreeSkipAmount = 1;  // one free skip as per official rules
 
     [SettingsTab name="Random Map Challenge" order="1" icon="Random"]
     void RenderRMCSettingTab(bool dontShowBaseInfos = false)
@@ -87,7 +87,7 @@ namespace PluginSettings
                 RMC_SurvivalMaxTime = 15;
                 RMC_PrepatchTagsWarns = true;
                 RMC_RUN_AUTOSAVE = true;
-                RMC_FreeSkipAMount = 1;
+                RMC_FreeSkipAmount = 1;
             }
             if (UI::BeginCombo("Goal", RMC_GoalMedal)){
                 for (uint i = 0; i < RMC::Medals.Length; i++) {
@@ -111,7 +111,7 @@ namespace PluginSettings
             UI::SetNextItemWidth(300);
             RMC_Duration = UI::SliderInt("Random Map Challenge duration (in minutes)", RMC_Duration, 10, 120);
             UI::SetNextItemWidth(300);
-            RMC_FreeSkipAMount = UI::SliderInt("Amount of free skips in RMC runs", RMC_FreeSkipAMount, 1, 200);
+            RMC_FreeSkipAmount = UI::SliderInt("Amount of free skips in RMC runs", RMC_FreeSkipAmount, 1, 200);
             UI::SetNextItemWidth(300);
             RMC_SurvivalMaxTime = UI::SliderInt("Maximum timer on Survival mode (in minutes)", RMC_SurvivalMaxTime, 2, 60);
 

--- a/src/Settings/RMCParameters.as
+++ b/src/Settings/RMCParameters.as
@@ -64,6 +64,9 @@ namespace PluginSettings
     [Setting hidden]
     bool RMC_RUN_AUTOSAVE = true;
 
+    [Setting hidden]
+    int RMC_FreeSkipAMount = 1;  // one free skip as per official rules
+
     [SettingsTab name="Random Map Challenge" order="1" icon="Random"]
     void RenderRMCSettingTab(bool dontShowBaseInfos = false)
     {
@@ -84,6 +87,7 @@ namespace PluginSettings
                 RMC_SurvivalMaxTime = 15;
                 RMC_PrepatchTagsWarns = true;
                 RMC_RUN_AUTOSAVE = true;
+                RMC_FreeSkipAMount = 1;
             }
             if (UI::BeginCombo("Goal", RMC_GoalMedal)){
                 for (uint i = 0; i < RMC::Medals.Length; i++) {
@@ -103,9 +107,11 @@ namespace PluginSettings
             RMC_AutoSwitch = UI::Checkbox("Automatically switch map when got "+RMC_GoalMedal+" medal", RMC_AutoSwitch);
             RMC_ExitMapOnEndTime = UI::Checkbox("Automatically quits the map when the timer is up", RMC_ExitMapOnEndTime);
             RMC_RUN_AUTOSAVE = UI::Checkbox("Automatically save the state of the current run when stopping the run", RMC_RUN_AUTOSAVE);
-
+            
             UI::SetNextItemWidth(300);
-            RMC_Duration = UI::SliderInt("Random Map Challange duration (in minutes)", RMC_Duration, 10, 120);
+            RMC_Duration = UI::SliderInt("Random Map Challenge duration (in minutes)", RMC_Duration, 10, 120);
+            UI::SetNextItemWidth(300);
+            RMC_FreeSkipAMount = UI::SliderInt("Amount of free skips in RMC runs", RMC_FreeSkipAMount, 1, 200);
             UI::SetNextItemWidth(300);
             RMC_SurvivalMaxTime = UI::SliderInt("Maximum timer on Survival mode (in minutes)", RMC_SurvivalMaxTime, 2, 60);
 

--- a/src/Utils/DataManager.as
+++ b/src/Utils/DataManager.as
@@ -44,6 +44,7 @@ namespace DataManager
         SaveFileData["CurrentRunTime"] = 0;
         SaveFileData["GotBelowMedalOnMap"] = false; // for challenge runs
         SaveFileData["GotGoalMedalOnMap"] = false; // for challenge runs
+        SaveFileData["FreeSkipsUsed"] = 0; // for RMC runs
         Json::ToFile(SAVE_DATA_LOCATION + gameMode + ".json", SaveFileData);
         RMC::CurrentRunData = SaveFileData;
     }

--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -20,6 +20,7 @@ namespace RMC
     int StartTimeCopyForSaveData = -1;
     int EndTimeCopyForSaveData = -1;
     RMCConfig@ config;
+    int FreeSkipsUsed = 0;
 
     array<string> Medals = {
         "Bronze",
@@ -144,6 +145,7 @@ namespace RMC
                             Challenge.BelowMedalCount = CurrentRunData["SecondaryCounterValue"];
                             Survival.Skips = 0;
                             GotBelowMedalOnCurrentMap = CurrentRunData["GotBelowMedalOnMap"];
+                            FreeSkipsUsed = CurrentRunData["FreeSkipsUsed"];
                         } else {
                             Challenge.BelowMedalCount = 0;
                             Survival.Skips = CurrentRunData["SecondaryCounterValue"];

--- a/src/Utils/RMC/ObjectiveMode.as
+++ b/src/Utils/RMC/ObjectiveMode.as
@@ -69,7 +69,7 @@ class RMObjective : RMC
         UI::SetCursorPos(pos_orig);
     }
 
-    void SkipButton() override
+    void SkipButtons() override
     {
         if (UI::Button(Icons::PlayCircleO + " Skip")) {
             if (RMC::IsPaused) RMC::IsPaused = false;

--- a/src/Utils/RMC/RMC.as
+++ b/src/Utils/RMC/RMC.as
@@ -265,8 +265,8 @@ class RMC
         else BelowMedal = PluginSettings::RMC_GoalMedal;
 
         UI::BeginDisabled(TM::IsPauseMenuDisplayed() || RMC::ClickedOnSkip);
-        if (PluginSettings::RMC_FreeSkipAMount > RMC::FreeSkipsUsed){
-            int skipsLeft = PluginSettings::RMC_FreeSkipAMount - RMC::FreeSkipsUsed;
+        if (PluginSettings::RMC_FreeSkipAmount > RMC::FreeSkipsUsed){
+            int skipsLeft = PluginSettings::RMC_FreeSkipAmount - RMC::FreeSkipsUsed;
             if(UI::Button(Icons::PlayCircleO + (RMC::GotBelowMedalOnCurrentMap ? " Take " + BelowMedal + " medal" : "Free Skip (" + skipsLeft + " left)"))) {
                 RMC::ClickedOnSkip = true;
                 if (RMC::IsPaused) RMC::IsPaused = false;

--- a/src/Utils/RMC/RMS.as
+++ b/src/Utils/RMC/RMS.as
@@ -55,26 +55,25 @@ class RMS : RMC
         UI::SetCursorPos(pos_orig);
     }
 
-    void SkipButton() override
+    void SkipButtons() override
     {
+        UI::BeginDisabled(TM::IsPauseMenuDisplayed() || RMC::ClickedOnSkip);
         if (UI::Button(Icons::PlayCircleO + " Skip")) {
             if (RMC::IsPaused) RMC::IsPaused = false;
             Skips += 1;
             Log::Trace("RMS: Skipping map");
             UI::ShowNotification("Please wait...");
             startnew(RMC::SwitchMap);
-            MX::MapInfo@ CurrentMapFromJson = MX::MapInfo(DataJson["recentlyPlayed"][0]);
-#if TMNEXT
-            if (PluginSettings::RMC_PrepatchTagsWarns && RMC::config.isMapHasPrepatchMapTags(CurrentMapFromJson)) {
-                RMC::EndTime += RMC::TimeSpentMap;
-            }
-#endif
         }
-        if (UI::OrangeButton(Icons::PlayCircleO + " Free Skip")) {
+#endif
+        if (UI::OrangeButton(Icons::PlayCircleO + " Skip Broken Map")) {
             if (!UI::IsOverlayShown()) UI::ShowOverlay();
             RMC::IsPaused = true;
-            Renderables::Add(SurvivalFreeSkipWarnModalDialog());
+            Renderables::Add(BrokenMapSkipWarnModalDialog());
         }
+
+        if (TM::IsPauseMenuDisplayed()) UI::SetPreviousTooltip("To skip the map, please exit the pause menu.");
+        UI::EndDisabled();
     }
 
     void NextMapButton() override

--- a/src/Utils/RMC/RMT.as
+++ b/src/Utils/RMC/RMT.as
@@ -397,14 +397,14 @@ class RMT : RMC
     {
         CGameCtnChallenge@ currentMap = cast<CGameCtnChallenge>(GetApp().RootMap);
         if (currentMap !is null) {
-            SkipButton();
+            SkipButtons();
             if (IS_DEV_MODE) {
                 DevButtons();
             }
         }
     }
 
-    void SkipButton() override
+    void SkipButtons() override
     {
         string BelowMedal = PluginSettings::RMC_GoalMedal;
         if (PluginSettings::RMC_GoalMedal == RMC::Medals[3]) BelowMedal = RMC::Medals[2];


### PR DESCRIPTION
fixes #100 

This changes the skip buttons to be more clear in their purpose and to always return the time if the map is broken.