### PR TITLE
Skip seen maps when fetching next RMT map

### DIFF
--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -100,6 +100,9 @@ namespace PluginSettings
     [Setting hidden]
     string Difficulty = SearchingDifficultys[0];
 
+    [Setting hidden]
+    bool SkipSeenMaps = false;
+
     [SettingsTab name="Searching" order="2" icon="Search"]
     void RenderSearchingSettingTab()
     {
@@ -231,6 +234,10 @@ namespace PluginSettings
             }
             UI::EndCombo();
         }
+
+        UI::NewLine();
+
+        SkipSeenMaps = UI::Checkbox("Skip Seen Maps", SkipSeenMaps);
     }
 
     array<int> ToggleMapTag(array<int> tags, int tagID)

--- a/src/Utils/RMC/RMT.as
+++ b/src/Utils/RMC/RMT.as
@@ -189,7 +189,7 @@ class RMT : RMC
         }
 
         if (PluginSettings::SkipSeenMaps) {
-            if (string(seenMaps[nextMap.TrackUID]).Length > 0) {
+            if (seenMaps.Exists(nextMap.TrackUID)) {
                 Log::Trace("Map has been seen, retrying...");
                 RMTFetchNextMap();
                 return;

--- a/src/Utils/RMC/RMT.as
+++ b/src/Utils/RMC/RMT.as
@@ -181,12 +181,6 @@ class RMT : RMC
         res["PlayedAt"] = playedAt;
         @nextMap = MX::MapInfo(res);
         Log::Trace("RMT: Next Random map: " + nextMap.Name + " (" + nextMap.TrackID + ")");
-        if (!MXNadeoServicesGlobal::CheckIfMapExistsAsync(nextMap.TrackUID)) {
-            Log::Trace("RMT: Next map is not on NadeoServices, retrying...");
-            @nextMap = null;
-            RMTFetchNextMap();
-            return;
-        }
 
         if (PluginSettings::SkipSeenMaps) {
             if (seenMaps.Exists(nextMap.TrackUID)) {
@@ -196,6 +190,13 @@ class RMT : RMC
             }
 
             seenMaps[nextMap.TrackUID] = nextMap.TrackUID;
+        }
+
+        if (!MXNadeoServicesGlobal::CheckIfMapExistsAsync(nextMap.TrackUID)) {
+            Log::Trace("RMT: Next map is not on NadeoServices, retrying...");
+            @nextMap = null;
+            RMTFetchNextMap();
+            return;
         }
 
         isFetchingNextMap = false;

--- a/src/Utils/RMC/RMT.as
+++ b/src/Utils/RMC/RMT.as
@@ -15,6 +15,7 @@ class RMT : RMC
     bool isSwitchingMap = false;
     bool pressedStopButton = false;
     bool isFetchingNextMap = false;
+    dictionary seenMaps;
 
     string GetModeName() override { return "Random Map Together";}
 
@@ -121,6 +122,7 @@ class RMT : RMC
         res["PlayedAt"] = playedAt;
         @currentMap = MX::MapInfo(res);
         Log::Trace("RMT: Random map: " + currentMap.Name + " (" + currentMap.TrackID + ")");
+        seenMaps[currentMap.TrackUID] = currentMap.TrackUID;
         UI::ShowNotification(Icons::InfoCircle + " RMT - Information on map switching", "Nadeo prevent sometimes when switching map too often and will not change map.\nIf after 10 seconds the podium screen is not shown, you can start a vote to change to next map in the game pause menu.", Text::ParseHexColor("#991703"));
 
         if (!MXNadeoServicesGlobal::CheckIfMapExistsAsync(currentMap.TrackUID)) {
@@ -185,6 +187,17 @@ class RMT : RMC
             RMTFetchNextMap();
             return;
         }
+
+        if (PluginSettings::SkipSeenMaps) {
+            if (string(seenMaps[nextMap.TrackUID]).Length > 0) {
+                Log::Trace("Map has been seen, retrying...");
+                RMTFetchNextMap();
+                return;
+            }
+
+            seenMaps[nextMap.TrackUID] = nextMap.TrackUID;
+        }
+
         isFetchingNextMap = false;
     }
 


### PR DESCRIPTION
There are times where maps are reused, expecially when providing a custom mappack. This caches the TrackUID in a dictionary and skips any already seen maps.

Tested with a mappack that has a single map in it: https://trackmania.exchange/mappack/view/3745