### PR TITLE
fix: prevent skript exceptions when save files are corrupted

### DIFF
--- a/src/Utils/DataManager.as
+++ b/src/Utils/DataManager.as
@@ -90,7 +90,7 @@ namespace DataManager
         };
         for (uint i = 0; i < requiredKeys.Length; i++) {
             if (!data.HasKey(requiredKeys[i])) {
-                Log::Error("Save file for " + gameMode + " is corrupted, missing key " + requiredKeys[i]);
+                Log::Error("Save file for " + gameMode + " is corrupted, missing key '" + requiredKeys[i] + "'");
                 return false;
             } else if (data[requiredKeys[i]].GetType() != requiredTypesOfKeys[i]) {
                 Log::Error("Save file for " + gameMode + " is corrupted, key '" + requiredKeys[i] + "' is of wrong type\n(Expected " + tostring(

--- a/src/Utils/DataManager.as
+++ b/src/Utils/DataManager.as
@@ -93,7 +93,7 @@ namespace DataManager
                 Log::Error("Save file for " + gameMode + " is corrupted, missing key " + requiredKeys[i]);
                 return false;
             } else if (data[requiredKeys[i]].GetType() != requiredTypesOfKeys[i]) {
-                Log::Error("Save file for " + gameMode + " is corrupted, key '" + requiredKeys[i] + "'' is of wrong type\n(Expected " + tostring(
+                Log::Error("Save file for " + gameMode + " is corrupted, key '" + requiredKeys[i] + "' is of wrong type\n(Expected " + tostring(
                     Json::Type(requiredTypesOfKeys[i])) + ", got " + tostring(
                         Json::Type(data[requiredKeys[i]].GetType())) + ")");
                 return false;


### PR DESCRIPTION
resolves #115 .

This is not a fix for the underlying issue if one exists. I have not found a way to reproduce corrupted save files without modifying files manually, so it is not likely to occur under normal circumstances (otherwise there'd be a lot more people complaining). If it still occurs, this will remove the corrupt file and start a new run. 