### PR TITLE
Add date interval as searching parameter

### DIFF
--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -65,6 +65,28 @@ namespace PluginSettings
 
     [Setting hidden]
     string MapName = "";
+    
+    [Setting hidden]
+    bool UseDateInterval = false;
+
+    [Setting hidden]
+    int FromYear = 2020;
+
+    [Setting hidden]
+    int FromMonth = 1;
+
+    [Setting hidden]
+    int FromDay = 1;
+
+    Time::Info currentDate = Time::Parse();
+    [Setting hidden]
+    int ToYear = currentDate.Year;
+
+    [Setting hidden]
+    int ToMonth = currentDate.Month;
+
+    [Setting hidden]
+    int ToDay = currentDate.Day;
 
     [Setting hidden]
     int64 MapPackID = 0;
@@ -161,6 +183,32 @@ namespace PluginSettings
             UI::EndCombo();
         }
 
+        UI::NewLine();
+        UseDateInterval = UI::Checkbox("Use date interval for map search", UseDateInterval);
+        UI::SetPreviousTooltip("If enabled, you will only get maps uploaded or updated inside the set date interval.\nSetting a very small interval can end in no map being found for a very long time and the API being spammed.\nPlease use responsibly.");
+        if (UseDateInterval) {
+            if (UI::BeginTable("tags", 2, UI::TableFlags::SizingFixedFit)) {
+                UI::TableNextColumn();
+                UI::Text("From date");
+                UI::SetNextItemWidth(150);
+                FromYear = UI::SliderInt("##From year", FromYear, 2020, currentDate.Year, "Year: %d");
+                UI::SetNextItemWidth(150);
+                FromMonth = UI::SliderInt("##From month", FromMonth, 1, 12, "Month: %.02d");
+                UI::SetNextItemWidth(150);
+                FromDay = UI::SliderInt("##From day", FromDay, 1, 31, "Day: %.02d");
+
+                UI::TableNextColumn();
+                UI::Text("To date");
+                UI::SetNextItemWidth(150);
+                ToYear = UI::SliderInt("##To year", ToYear, 2020, currentDate.Year, "Year: %d");
+                UI::SetNextItemWidth(150);
+                ToMonth = UI::SliderInt("##To month", ToMonth, 1, 12, "Month: %.02d");
+                UI::SetNextItemWidth(150);
+                ToDay = UI::SliderInt("##To day", ToDay, 1, 31, "Day: %.02d");
+                UI::EndTable();
+            }
+        }
+        
         UI::NewLine();
 
         UI::SetNextItemWidth(200);

--- a/src/Utils/Dates.as
+++ b/src/Utils/Dates.as
@@ -18,3 +18,13 @@ class Date
         return !isBefore(date);
     }
 }
+
+SQLite::Database@ cursedTimeDB = SQLite::Database(":memory:");
+int64 DateFromStrTime(const string &in inTime) {
+    auto st = cursedTimeDB.Prepare("SELECT unixepoch(?) as x");
+    st.Bind(1, inTime);
+    st.Execute();
+    st.NextRow();
+    st.NextRow();
+    return st.GetColumnInt64("x");
+}

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -116,13 +116,6 @@ namespace MX
         res["PlayedAt"] = playedAt;
 
         MX::MapInfo@ map = MX::MapInfo(res);
-        bool isValid = isMapInsideDateParams(map);
-
-        if(PluginSettings::CustomRules && !isValid){
-            Log::Warn("Looking for new map inside date params...");
-            PreloadRandomMap();
-            return;
-        }
 
         if (map is null){
             Log::Warn("Map is null, retrying...");
@@ -149,6 +142,18 @@ namespace MX
         }
 #endif
 
+        if (
+            (((RMC::IsRunning || RMC::IsStarting) && PluginSettings::CustomRules && PluginSettings::UseDateInterval)
+            || (!RMC::IsRunning && !RMC::IsStarting && PluginSettings::UseDateInterval))
+        ) {
+            bool isValidDate = isMapInsideDateParams(map);
+            if(!isValidDate){
+                Log::Warn("Looking for new map inside date params...");
+                PreloadRandomMap();
+                return;
+            }
+        }
+        
         if (
             (((RMC::IsRunning || RMC::IsStarting) && PluginSettings::CustomRules && PluginSettings::MapAuthorNameNeedsExactMatch)
             || (!RMC::IsRunning && !RMC::IsStarting && PluginSettings::MapAuthorNameNeedsExactMatch)) && PluginSettings::MapAuthor != ""

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -62,6 +62,15 @@ namespace MX
         return retval;
     }
 
+    bool isMapInsideDateParams(const MX::MapInfo@ &in map) {
+        int64 mapUploadedDate = DateFromStrTime(map.UploadedAt);
+        int64 mapUpdatedDate = DateFromStrTime(map.UpdatedAt);
+        int64 toDate = DateFromStrTime(PluginSettings::ToYear + "-" + Text::Format("%.02d", PluginSettings::ToMonth) + "-" + Text::Format("%.02d", PluginSettings::ToDay) + "T00:00:00.00");
+        int64 fromDate = DateFromStrTime(PluginSettings::FromYear + "-" + Text::Format("%.02d", PluginSettings::FromMonth) + "-" + Text::Format("%.02d", PluginSettings::FromDay) + "T00:00:00.00");
+        return (mapUpdatedDate < toDate && mapUpdatedDate > fromDate);
+    }
+
+
     void PreloadRandomMap()
     {
         isLoadingPreload = true;
@@ -107,6 +116,13 @@ namespace MX
         res["PlayedAt"] = playedAt;
 
         MX::MapInfo@ map = MX::MapInfo(res);
+        bool isValid = isMapInsideDateParams(map);
+
+        if(PluginSettings::CustomRules && !isValid){
+            Log::Warn("Looking for new map inside date params...");
+            PreloadRandomMap();
+            return;
+        }
 
         if (map is null){
             Log::Warn("Map is null, retrying...");


### PR DESCRIPTION
fixes #128 

Adds new Searching parameter to allow filtering maps inside a date interval. This is useful to be able to play maps only before an important game patch or update, for example.
This setting is only used if CustomRules setting is also set to true, to prevent these runs getting into the official leaderboard.

![image](https://github.com/user-attachments/assets/15b616e2-87f9-4759-8bb6-143ded0989db)

Date parsing from a string is done using [this suggestion](https://github.com/MisfitMaid/tm-ticker/blob/d8758b5439317dd0fe8357408013f4731557986b/Helpers.as#L19) by @misfitmaid