### PR TITLE
Fix free skips

### DIFF
--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -143,6 +143,7 @@ namespace RMC
                         GoalMedalCount = 0;
                         Challenge.BelowMedalCount = 0;
                         Survival.Skips = 0;
+                        FreeSkipsUsed = 0;
                         GotBelowMedalOnCurrentMap = false;
                         GotGoalMedalOnCurrentMap = false;
                     } else {


### PR DESCRIPTION
When using a free skip during a run, RMC::FreeSkipsUsed is increased by one

https://github.com/GreepTheSheep/openplanet-MXRandom/blob/85ce6d140b749f70540cac08ababde1c35dec863/src/Utils/RMC/RMC.as#L281

but this counter isn't reset between runs, so when comparing it to the free skip amount set by the user, it's counting the total amount of skips used since the plugin was loaded

https://github.com/GreepTheSheep/openplanet-MXRandom/blob/85ce6d140b749f70540cac08ababde1c35dec863/src/Utils/RMC/RMC.as#L273

Fixes #133 