### PR TITLE
Only check for WR medal on TMNEXT

### DIFF
--- a/src/Utils/RMC/RMC.as
+++ b/src/Utils/RMC/RMC.as
@@ -133,8 +133,10 @@ class RMC
     void RenderGoalMedal()
     {
         UI::AlignTextToFramePadding();
+#if TMNEXT
         if (PluginSettings::RMC_GoalMedal == RMC::Medals[4]) UI::Image(WRTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
-        else if (PluginSettings::RMC_GoalMedal == RMC::Medals[3]) UI::Image(AuthorTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
+#endif
+        if (PluginSettings::RMC_GoalMedal == RMC::Medals[3]) UI::Image(AuthorTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
         else if (PluginSettings::RMC_GoalMedal == RMC::Medals[2]) UI::Image(GoldTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
         else if (PluginSettings::RMC_GoalMedal == RMC::Medals[1]) UI::Image(SilverTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
         else if (PluginSettings::RMC_GoalMedal == RMC::Medals[0]) UI::Image(BronzeTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
@@ -153,8 +155,10 @@ class RMC
         if (PluginSettings::RMC_GoalMedal != RMC::Medals[0])
         {
             UI::AlignTextToFramePadding();
+#if TMNEXT
             if (PluginSettings::RMC_GoalMedal == RMC::Medals[4]) UI::Image(AuthorTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
-            else if (PluginSettings::RMC_GoalMedal == RMC::Medals[3]) UI::Image(GoldTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
+#endif
+            if (PluginSettings::RMC_GoalMedal == RMC::Medals[3]) UI::Image(GoldTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
             else if (PluginSettings::RMC_GoalMedal == RMC::Medals[2]) UI::Image(SilverTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
             else if (PluginSettings::RMC_GoalMedal == RMC::Medals[1]) UI::Image(BronzeTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
             else UI::Text(PluginSettings::RMC_GoalMedal);
@@ -263,11 +267,8 @@ class RMC
     void SkipButtons()
     {
         string BelowMedal = PluginSettings::RMC_GoalMedal;
-        if (PluginSettings::RMC_GoalMedal == RMC::Medals[4]) BelowMedal = RMC::Medals[3];
-        else if (PluginSettings::RMC_GoalMedal == RMC::Medals[3]) BelowMedal = RMC::Medals[2];
-        else if (PluginSettings::RMC_GoalMedal == RMC::Medals[2]) BelowMedal = RMC::Medals[1];
-        else if (PluginSettings::RMC_GoalMedal == RMC::Medals[1]) BelowMedal = RMC::Medals[0];
-        else BelowMedal = PluginSettings::RMC_GoalMedal;
+        int medalIndex = RMC::Medals.Find(PluginSettings::RMC_GoalMedal);
+        if (medalIndex > 0) BelowMedal = RMC::Medals[medalIndex - 1];
 
         UI::BeginDisabled(TM::IsPauseMenuDisplayed() || RMC::ClickedOnSkip);
         if (PluginSettings::RMC_FreeSkipAmount > RMC::FreeSkipsUsed){

--- a/src/Utils/RMC/RMT.as
+++ b/src/Utils/RMC/RMT.as
@@ -423,10 +423,8 @@ class RMT : RMC
     void SkipButtons() override
     {
         string BelowMedal = PluginSettings::RMC_GoalMedal;
-        if (PluginSettings::RMC_GoalMedal == RMC::Medals[3]) BelowMedal = RMC::Medals[2];
-        else if (PluginSettings::RMC_GoalMedal == RMC::Medals[2]) BelowMedal = RMC::Medals[1];
-        else if (PluginSettings::RMC_GoalMedal == RMC::Medals[1]) BelowMedal = RMC::Medals[0];
-        else BelowMedal = PluginSettings::RMC_GoalMedal;
+        int medalIndex = RMC::Medals.Find(PluginSettings::RMC_GoalMedal);
+        if (medalIndex > 0) BelowMedal = RMC::Medals[medalIndex - 1];
 
         UI::BeginDisabled(RMC::ClickedOnSkip || isSwitchingMap);
         if(UI::Button(Icons::PlayCircleO + " Skip" + (RMC::GotBelowMedalOnCurrentMap ? " and take " + BelowMedal + " medal" : ""))) {
@@ -454,10 +452,9 @@ class RMT : RMC
     void RenderScores()
     {
         string BelowMedal = PluginSettings::RMC_GoalMedal;
-        if (PluginSettings::RMC_GoalMedal == RMC::Medals[3]) BelowMedal = RMC::Medals[2];
-        else if (PluginSettings::RMC_GoalMedal == RMC::Medals[2]) BelowMedal = RMC::Medals[1];
-        else if (PluginSettings::RMC_GoalMedal == RMC::Medals[1]) BelowMedal = RMC::Medals[0];
-        else BelowMedal = PluginSettings::RMC_GoalMedal;
+        int medalIndex = RMC::Medals.Find(PluginSettings::RMC_GoalMedal);
+        if (medalIndex > 0) BelowMedal = RMC::Medals[medalIndex - 1];
+
         int tableCols = 3;
         if (PluginSettings::RMC_GoalMedal == RMC::Medals[0]) tableCols = 2;
         if (UI::BeginTable("RMTScores", tableCols)) {


### PR DESCRIPTION
Plugin stopped working on MP4 because it tries to check if the selected goal is WRs, but that medal is only included in TM2020

https://github.com/GreepTheSheep/openplanet-MXRandom/blob/55af5804ae91674d02b400b5988443b27ff8a941/src/Utils/RMC/GlobalProperties.as#L27-L35

This PR makes it so it only checks for that medal if the game is TMNEXT. Also simplifies the belowMedal check while fixing the issue

<details>
<summary>Proof of the plugin working</summary>

![20241126151935_1](https://github.com/user-attachments/assets/5355a286-27ff-4164-afb9-8e51c308bb5e)

</details>

P.S.: Tried to fix the issue without touching/changing the code too much just in case, but let me know if you have a different idea to fix it

Fixes #129 