### PR TITLE
Improve PB fetching to avoid log spam, fix autosaves

### DIFF
--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -150,6 +150,7 @@ namespace RMC
                         Challenge.BelowMedalCount = 0;
                         Survival.Skips = 0;
                         FreeSkipsUsed = 0;
+                        CurrentTimeOnMap = -1;
                         GotBelowMedalOnCurrentMap = false;
                         GotGoalMedalOnCurrentMap = false;
                     } else {
@@ -274,7 +275,7 @@ namespace RMC
                     Log::Trace("Medal: " + medal);
                 }
 
-                if (CurrentTimeOnMap > time) {
+                if (CurrentTimeOnMap > time || CurrentTimeOnMap == -1) {
                     // PB
                     CurrentTimeOnMap = time;
                     CreateSave();
@@ -322,6 +323,7 @@ namespace RMC
         GotBelowMedalOnCurrentMap = false;
         TimeSpawnedMap = Time::Now;
         ClickedOnSkip = false;
+        CurrentTimeOnMap = -1;
         HandledRun = false;
         CurrentMedal = -1;
         LastRun = -1;

--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -215,8 +215,13 @@ namespace RMC
             int time = -1;
 #if MP4
             CGameCtnPlayground@ GameCtnPlayground = cast<CGameCtnPlayground>(app.CurrentPlayground);
-            if (GameCtnPlayground.PlayerRecordedGhost !is null){
-                time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
+            if (GameCtnPlayground !is null && GameCtnPlayground.GameTerminals.Length > 0) {
+                CTrackManiaPlayer@ player = cast<CTrackManiaPlayer>(GameCtnPlayground.GameTerminals[0].ControlledPlayer);
+                if (player !is null && player.ScriptAPI.RaceState == CTrackManiaPlayer::ERaceState::Finished) {
+                    if (GameCtnPlayground.PlayerRecordedGhost !is null) {
+                        time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
+                    } else time = -1;
+                } else time = -1;
             } else time = -1;
 #elif TMNEXT
             CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode>(app.PlaygroundScript);

--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -222,15 +222,10 @@ namespace RMC
             int time = -1;
 #if MP4
             CGameCtnPlayground@ GameCtnPlayground = cast<CGameCtnPlayground>(app.CurrentPlayground);
-            if (GameCtnPlayground !is null && GameCtnPlayground.GameTerminals.Length > 0) {
-                CTrackManiaPlayer@ player = cast<CTrackManiaPlayer>(GameCtnPlayground.GameTerminals[0].ControlledPlayer);
-                if (player !is null && HandledRun && player.ScriptAPI.RaceState != CTrackManiaPlayer::ERaceState::Finished) {
+            if (GameCtnPlayground !is null && GameCtnPlayground.PlayerRecordedGhost !is null) {
+                if (GameCtnPlayground.PlayerRecordedGhost.RaceTime != LastRun) {
                     HandledRun = false;
-                    time = -1;
-                } else if (player !is null && !HandledRun && player.ScriptAPI.RaceState == CTrackManiaPlayer::ERaceState::Finished) {
-                    if (GameCtnPlayground.PlayerRecordedGhost !is null) {
-                        time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
-                    } else time = -1;
+                    time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
                 } else time = -1;
             } else time = -1;
 #elif TMNEXT

--- a/src/Utils/RMC/ObjectiveMode.as
+++ b/src/Utils/RMC/ObjectiveMode.as
@@ -162,15 +162,14 @@ class RMObjective : RMC
 #endif
             }
 
-            if (RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal) && !RMC::GotGoalMedalOnCurrentMap){
+            if (!RMC::GotGoalMedalOnCurrentMap && RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal)){
                 RMC::GoalMedalCount += 1;
                 RMC::GotGoalMedalOnCurrentMap = true;
                 GotGoalMedalNotification();
-            }
-            if (
-                RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal)-1 &&
+            } else if (
                 !RMC::GotGoalMedalOnCurrentMap &&
-                PluginSettings::RMC_GoalMedal != RMC::Medals[0])
+                PluginSettings::RMC_GoalMedal != RMC::Medals[0] &&
+                RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal)-1)
             {
                 GotBelowGoalMedalNotification();
                 RMC::GotBelowMedalOnCurrentMap = true;

--- a/src/Utils/RMC/ObjectiveMode.as
+++ b/src/Utils/RMC/ObjectiveMode.as
@@ -168,6 +168,7 @@ class RMObjective : RMC
                 GotGoalMedalNotification();
             } else if (
                 !RMC::GotGoalMedalOnCurrentMap &&
+                !RMC::GotBelowMedalOnCurrentMap &&
                 PluginSettings::RMC_GoalMedal != RMC::Medals[0] &&
                 RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal)-1)
             {

--- a/src/Utils/RMC/RMC.as
+++ b/src/Utils/RMC/RMC.as
@@ -456,16 +456,15 @@ class RMC
 #endif
             }
 
-            if (RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal) && !RMC::GotGoalMedalOnCurrentMap){
+            if (!RMC::GotGoalMedalOnCurrentMap && RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal)){
                 GotGoalMedalNotification();
                 RMC::GoalMedalCount += 1;
                 RMC::GotGoalMedalOnCurrentMap = true;
                 RMC::CreateSave();
-            }
-            if (
-                RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal)-1 &&
+            } else if (
                 !RMC::GotGoalMedalOnCurrentMap &&
-                PluginSettings::RMC_GoalMedal != RMC::Medals[0])
+                PluginSettings::RMC_GoalMedal != RMC::Medals[0] &&
+                RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal)-1)
             {
                 GotBelowGoalMedalNotification();
                 RMC::GotBelowMedalOnCurrentMap = true;

--- a/src/Utils/RMC/RMC.as
+++ b/src/Utils/RMC/RMC.as
@@ -463,6 +463,7 @@ class RMC
                 RMC::CreateSave();
             } else if (
                 !RMC::GotGoalMedalOnCurrentMap &&
+                !RMC::GotBelowMedalOnCurrentMap &&
                 PluginSettings::RMC_GoalMedal != RMC::Medals[0] &&
                 RMC::GetCurrentMapMedal() >= RMC::Medals.Find(PluginSettings::RMC_GoalMedal)-1)
             {


### PR DESCRIPTION
Once the plugin started working again for MP4, I was getting lags/freezes after playing for some minutes. Coincidentally, I noticed the log file was getting absurdly large, which ended up being the cause of the freezes 

![image](https://github.com/user-attachments/assets/acda5454-afad-49cf-a61a-f2a1a777f2de)

This happens because, in dev mode, RMC::GetCurrentMapMedal prints the current medal stats almost every frame. This is caused due to multiple reasons:

* MP4 PB fetching only checked if there was a ghost, so it would repeatedly get the same time over and over again
* In the if statements for each mode, it would first get the current medal, and _then_ see if the player already had the medal. This is fixed by inverting the order of conditions
* For the below medal check, the if statement was only checking if the player already had the goal medal, but not the one below (so even if you had gold, it would run the check anyway)
* I also added some flags to only check a time once, similar to what other plugins like Grinding Stats do

Finally, PB autosaves didn't work because CurrentTimeOnMap wasn't being reset between maps, and since the default value is -1, none of the PBs were lower than that

P.S.: I opened a single PR for these changes because they are all related to GetCurrentMapMedal