### PR TITLE
Make custom parameters more intuitive, few fixes

### DIFF
--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -274,6 +274,7 @@ namespace PluginSettings
         }
 
         TagInclusiveSearch = UI::Checkbox("Tag inclusive search", TagInclusiveSearch);
+        UI::SetPreviousTooltip("If enabled, maps must contain all selected tags.");
 
         MapTags = ConvertArrayToList(MapTagsArr);
         ExcludeMapTags = ConvertArrayToList(ExcludeMapTagsArr);
@@ -299,6 +300,7 @@ namespace PluginSettings
         UI::NewLine();
 
         SkipSeenMaps = UI::Checkbox("Skip Seen Maps", SkipSeenMaps);
+        UI::SetPreviousTooltip("If enabled, every map will only appear once per run.");
     }
 
     array<int> ToggleMapTag(array<int> tags, int tagID)

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -137,6 +137,8 @@ namespace PluginSettings
         CustomRules = UI::Checkbox("\\$fc0"+Icons::ExclamationTriangle+" \\$zUse these parameters in RMC. Forbidden on official Leaderboard.", CustomRules);
         UI::Separator();
 
+        UI::BeginDisabled(!CustomRules);
+
         if (UI::OrangeButton("Reset to default")){
             MapLengthOperator = SearchingMapLengthOperators[0];
             MapLength = SearchingMapLengths[0];
@@ -301,6 +303,8 @@ namespace PluginSettings
 
         SkipSeenMaps = UI::Checkbox("Skip Seen Maps", SkipSeenMaps);
         UI::SetPreviousTooltip("If enabled, every map will only appear once per run.");
+
+        UI::EndDisabled();
     }
 
     array<int> ToggleMapTag(array<int> tags, int tagID)

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -134,7 +134,7 @@ namespace PluginSettings
     [SettingsTab name="Searching" order="2" icon="Search"]
     void RenderSearchingSettingTab()
     {
-        CustomRules = UI::Checkbox("\\$fc0"+Icons::ExclamationTriangle+" \\$zUse these parameters in RMC. Forbidden on official Leaderboard.", CustomRules);
+        CustomRules = UI::Checkbox("\\$fc0"+Icons::ExclamationTriangle+" \\$zUse custom parameters. Forbidden on official leaderboards.", CustomRules);
         UI::Separator();
 
         UI::BeginDisabled(!CustomRules);

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -247,9 +247,9 @@ namespace PluginSettings
 
         if (UI::BeginTable("tags", 2, UI::TableFlags::SizingFixedFit)) {
             UI::TableNextColumn();
-            UI::Text("Include Tags");
+            UI::Text("Include Tags" + (MapTagsArr.Length == 0 ? "" : " (" + MapTagsArr.Length + " selected)"));
             UI::TableNextColumn();
-            UI::Text("Exclude Tags");
+            UI::Text("Exclude Tags" + (ExcludeMapTagsArr.Length == 0 ? "" : " (" + ExcludeMapTagsArr.Length + " selected)"));
 
             UI::TableNextColumn();
             if (UI::BeginListBox("##Include Tags", vec2(200, 300))){

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -200,7 +200,7 @@ namespace PluginSettings
         UseDateInterval = UI::Checkbox("Use date interval for map search", UseDateInterval);
         UI::SetPreviousTooltip("If enabled, you will only get maps uploaded or updated inside the set date interval.\nSetting a very small interval can end in no map being found for a very long time and the API being spammed.\nPlease use responsibly.");
         if (UseDateInterval) {
-            if (UI::BeginTable("tags", 2, UI::TableFlags::SizingFixedFit)) {
+            if (UI::BeginTable("DateIntervals", 2, UI::TableFlags::SizingFixedFit)) {
                 UI::TableNextColumn();
                 UI::Text("From date");
                 UI::SetNextItemWidth(150);

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -54,6 +54,12 @@ namespace PluginSettings
 
     array<string> MapAuthorNamesArr = {};
 
+#if TMNEXT
+    const int releaseYear = 2020;
+#else
+    const int releaseYear = 2011;
+#endif
+
     [Setting hidden]
     string MapLength = SearchingMapLengths[0];
 
@@ -70,7 +76,7 @@ namespace PluginSettings
     bool UseDateInterval = false;
 
     [Setting hidden]
-    int FromYear = 2020;
+    int FromYear = releaseYear;
 
     [Setting hidden]
     int FromMonth = 1;
@@ -191,7 +197,7 @@ namespace PluginSettings
                 UI::TableNextColumn();
                 UI::Text("From date");
                 UI::SetNextItemWidth(150);
-                FromYear = UI::SliderInt("##From year", FromYear, 2020, currentDate.Year, "Year: %d");
+                FromYear = UI::SliderInt("##From year", FromYear, releaseYear, currentDate.Year, "Year: %d");
                 UI::SetNextItemWidth(150);
                 FromMonth = UI::SliderInt("##From month", FromMonth, 1, 12, "Month: %.02d");
                 UI::SetNextItemWidth(150);
@@ -200,7 +206,7 @@ namespace PluginSettings
                 UI::TableNextColumn();
                 UI::Text("To date");
                 UI::SetNextItemWidth(150);
-                ToYear = UI::SliderInt("##To year", ToYear, 2020, currentDate.Year, "Year: %d");
+                ToYear = UI::SliderInt("##To year", ToYear, releaseYear, currentDate.Year, "Year: %d");
                 UI::SetNextItemWidth(150);
                 ToMonth = UI::SliderInt("##To month", ToMonth, 1, 12, "Month: %.02d");
                 UI::SetNextItemWidth(150);

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -140,6 +140,13 @@ namespace PluginSettings
         if (UI::OrangeButton("Reset to default")){
             MapLengthOperator = SearchingMapLengthOperators[0];
             MapLength = SearchingMapLengths[0];
+            UseDateInterval = false;
+            FromYear = releaseYear;
+            FromMonth = 1;
+            FromDay = 1;
+            ToYear = currentDate.Year;
+            ToMonth = currentDate.Month;
+            ToDay = currentDate.Day;
             TagInclusiveSearch = false;
             MapAuthor = "";
             MapName = "";

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -204,6 +204,7 @@ namespace PluginSettings
         if (UseDateInterval) {
             if (UI::BeginTable("DateIntervals", 2, UI::TableFlags::SizingFixedFit)) {
                 UI::TableNextColumn();
+                UI::AlignTextToFramePadding();
                 UI::Text("From date");
                 UI::SetNextItemWidth(150);
                 FromYear = UI::SliderInt("##From year", FromYear, releaseYear, currentDate.Year, "Year: %d");
@@ -213,6 +214,7 @@ namespace PluginSettings
                 FromDay = UI::SliderInt("##From day", FromDay, 1, 31, "Day: %.02d");
 
                 UI::TableNextColumn();
+                UI::AlignTextToFramePadding();
                 UI::Text("To date");
                 UI::SetNextItemWidth(150);
                 ToYear = UI::SliderInt("##To year", ToYear, releaseYear, currentDate.Year, "Year: %d");
@@ -249,8 +251,10 @@ namespace PluginSettings
 
         if (UI::BeginTable("tags", 2, UI::TableFlags::SizingFixedFit)) {
             UI::TableNextColumn();
+            UI::AlignTextToFramePadding();
             UI::Text("Include Tags" + (MapTagsArr.Length == 0 ? "" : " (" + MapTagsArr.Length + " selected)"));
             UI::TableNextColumn();
+            UI::AlignTextToFramePadding();
             UI::Text("Exclude Tags" + (ExcludeMapTagsArr.Length == 0 ? "" : " (" + ExcludeMapTagsArr.Length + " selected)"));
 
             UI::TableNextColumn();

--- a/src/Utils/MX/Methods/FetchMapTags.as
+++ b/src/Utils/MX/Methods/FetchMapTags.as
@@ -18,6 +18,8 @@ namespace MX
                 m_mapTags.InsertLast(MapTag(resNet[i]));
             }
 
+            m_mapTags.Sort(function(a,b) { return a.Name < b.Name; });
+
             print(m_mapTags.Length + " tags loaded");
             APIDown = false;
             APIRefreshing = false;


### PR DESCRIPTION
This PR tries to partially address #102, since I also got confused about them before. The changes are mostly visual and don't affect functionality

* Make custom rules checkbox text generic, since they affect all game modes as far as I know.
* Disable all custom parameters if the custom rules checkbox isn't enabled. This should make it clear that you need to enable this setting to use them.
* Include tag count when there's any tag selected and sort them alphabetically
![image](https://github.com/user-attachments/assets/13611e60-e1b9-4963-974e-4be484b48a3b)
* Add tooltips for the tag inclusive and skip seen maps checkboxes

This PR also fixes the following issues:

* Minimum value for the year slider was 2020 for MP4 too
* Date interval table used the same name as the tags table. This would shrink the tags table when the date interval one was rendered
* Date intervals values weren't being reset when resetting parameters to default

This was included in a single PR because the changes are small and related to the custom parameters tab