### PR TITLE
Fix timer for the first map in a fresh run

### DIFF
--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -145,7 +145,7 @@ namespace RMC
             if (GamePlayground !is null){
                 if (!IsInited) {
                     if (!ContinueSavedRun) {
-                        TimeSpawnedMap = -1;
+                        TimeSpentMap = -1;
                         GoalMedalCount = 0;
                         Challenge.BelowMedalCount = 0;
                         Survival.Skips = 0;
@@ -195,7 +195,7 @@ namespace RMC
                     } else if (RMC::selectedGameMode == GameMode::Objective){
                         Objective.StartTimer();
                     }
-                    TimeSpawnedMap = int(Time::Now) - int(CurrentRunData["TimeSpentOnMap"]);
+                    TimeSpawnedMap = !RMC::ContinueSavedRun ? Time::Now : int(Time::Now) - int(CurrentRunData["TimeSpentOnMap"]);
                     // Clear the currently saved data so you cannot load into the same state multiple times
                     DataManager::RemoveCurrentSaveFile();
                     DataManager::CreateSaveFile();


### PR DESCRIPTION
Noticed this issue while watching a stream (notice how it's a fresh run but with an hour spent on the map)

![image](https://github.com/user-attachments/assets/d115f5f1-040f-4b18-8464-453f81a67cc9)

VOD to see the issue: https://www.twitch.tv/videos/2311715689?t=00h06m45s