### PR TITLE
Migrate to MX 2.0

### DIFF
--- a/src/Constants.as
+++ b/src/Constants.as
@@ -38,3 +38,24 @@ Json::Value DataJson                    = Json::FromFile(DATA_JSON_LOCATION);
 Json::Value DataJsonOldVersion          = Json::FromFile(IO::FromDataFolder("TMXRandom_Data.json"));
 const string DATA_JSON_LOCATION_DATADIR = IO::FromDataFolder("MXRandom_Data.json");
 Json::Value DataJsonFromDataFolder      = Json::FromFile(DATA_JSON_LOCATION_DATADIR);
+
+const array<string> MAP_FIELDS_ARRAY = {
+	"MapId",
+	"MapUid",
+	"OnlineMapId",
+	"Uploader.UserId",
+	"Uploader.Name",
+	"MapType",
+	"UploadedAt",
+	"UpdatedAt",
+	"Name",
+	"GbxMapName",
+	"TitlePack",
+	"Length",
+	"Medals.Author",
+	"AwardCount",
+	"ServerSizeExceeded",
+	"Tags",
+	"Exebuild"
+};
+const string MAP_FIELDS = string::Join(MAP_FIELDS_ARRAY, ",");

--- a/src/Constants.as
+++ b/src/Constants.as
@@ -38,6 +38,7 @@ Json::Value DataJson                    = Json::FromFile(DATA_JSON_LOCATION);
 Json::Value DataJsonOldVersion          = Json::FromFile(IO::FromDataFolder("TMXRandom_Data.json"));
 const string DATA_JSON_LOCATION_DATADIR = IO::FromDataFolder("MXRandom_Data.json");
 Json::Value DataJsonFromDataFolder      = Json::FromFile(DATA_JSON_LOCATION_DATADIR);
+const string MX_V1_BACKUP_LOCATION      = IO::FromStorageFolder("Old/");
 
 const array<string> MAP_FIELDS_ARRAY = {
 	"MapId",

--- a/src/Exports/ExportsCode.as
+++ b/src/Exports/ExportsCode.as
@@ -14,15 +14,6 @@ namespace MXRandom
     string GetRandomMapUrlAsync() {
         string URL = MX::CreateQueryURL();
         Json::Value res = API::GetAsync(URL)["Results"][0];
-        Json::Value playedAt = Json::Object();
-        Time::Info date = Time::Parse();
-        playedAt["Year"] = date.Year;
-        playedAt["Month"] = date.Month;
-        playedAt["Day"] = date.Day;
-        playedAt["Hour"] = date.Hour;
-        playedAt["Minute"] = date.Minute;
-        playedAt["Second"] = date.Second;
-        res["PlayedAt"] = playedAt;
         MX::MapInfo@ map = MX::MapInfo(res);
         return PluginSettings::RMC_MX_Url+"/mapgbx/"+map.MapId;
     }

--- a/src/Exports/ExportsCode.as
+++ b/src/Exports/ExportsCode.as
@@ -24,6 +24,6 @@ namespace MXRandom
         playedAt["Second"] = date.Second;
         res["PlayedAt"] = playedAt;
         MX::MapInfo@ map = MX::MapInfo(res);
-        return PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID;
+        return PluginSettings::RMC_MX_Url+"/maps/download/"+map.MapId;
     }
 }

--- a/src/Exports/ExportsCode.as
+++ b/src/Exports/ExportsCode.as
@@ -13,7 +13,7 @@ namespace MXRandom
 
     string GetRandomMapUrlAsync() {
         string URL = MX::CreateQueryURL();
-        Json::Value res = API::GetAsync(URL)["results"][0];
+        Json::Value res = API::GetAsync(URL)["Results"][0];
         Json::Value playedAt = Json::Object();
         Time::Info date = Time::Parse();
         playedAt["Year"] = date.Year;
@@ -24,6 +24,6 @@ namespace MXRandom
         playedAt["Second"] = date.Second;
         res["PlayedAt"] = playedAt;
         MX::MapInfo@ map = MX::MapInfo(res);
-        return PluginSettings::RMC_MX_Url+"/maps/download/"+map.MapId;
+        return PluginSettings::RMC_MX_Url+"/mapgbx/"+map.MapId;
     }
 }

--- a/src/Interface/ModalDialogs/DataMigrationWizardModalDialog.as
+++ b/src/Interface/ModalDialogs/DataMigrationWizardModalDialog.as
@@ -95,8 +95,8 @@ class DataMigrationWizardModalDialog : ModalDialog
         UI::NewLine();
         if (m_MapsFetched.Length > 0 && UI::TreeNode("Saved maps")){
             for (uint i = 0; i < m_MapsFetched.Length; i++){
-                UI::Text(m_MapsFetched[i].TrackID + ": " + m_MapsFetched[i].Name + " - " + m_MapsFetched[i].Username);
-                if (UI::IsItemClicked()) OpenBrowserURL("https://"+MX_URL+"/maps/"+m_MapsFetched[i].TrackID);
+                UI::Text(m_MapsFetched[i].MapId + ": " + m_MapsFetched[i].Name + " - " + m_MapsFetched[i].Username);
+                if (UI::IsItemClicked()) OpenBrowserURL("https://"+MX_URL+"/maps/"+m_MapsFetched[i].MapId);
             }
             UI::TreePop();
         }

--- a/src/Interface/ModalDialogs/DataMigrationWizardModalDialog.as
+++ b/src/Interface/ModalDialogs/DataMigrationWizardModalDialog.as
@@ -96,7 +96,7 @@ class DataMigrationWizardModalDialog : ModalDialog
         if (m_MapsFetched.Length > 0 && UI::TreeNode("Saved maps")){
             for (uint i = 0; i < m_MapsFetched.Length; i++){
                 UI::Text(m_MapsFetched[i].MapId + ": " + m_MapsFetched[i].Name + " - " + m_MapsFetched[i].Username);
-                if (UI::IsItemClicked()) OpenBrowserURL("https://"+MX_URL+"/maps/"+m_MapsFetched[i].MapId);
+                if (UI::IsItemClicked()) OpenBrowserURL("https://"+MX_URL+"/mapshow/"+m_MapsFetched[i].MapId);
             }
             UI::TreePop();
         }

--- a/src/Interface/ModalDialogs/MX2MigrationWizardModalDialog.as
+++ b/src/Interface/ModalDialogs/MX2MigrationWizardModalDialog.as
@@ -3,6 +3,7 @@ class MX2MigrationWizardModalDialog : ModalDialog
     int m_stage = 0;
     int m_migrationStep = 0;
     bool migrationCompleted = false;
+    bool createBackup = false;
     array<int> m_MXIds;
     array<MX::MapInfo@> m_MapsFetched;
 
@@ -51,12 +52,15 @@ class MX2MigrationWizardModalDialog : ModalDialog
         UI::PopFont();
         UI::NewLine();
 
+        if (createBackup) UI::Text((m_migrationStep > 0 ? "\\$090" + Icons::Check : "\\$f80" + Hourglass) + " \\$zBacking up old data...");
         UI::Text((m_migrationStep > 0 ? "\\$090" + Icons::Check : "\\$f80" + Hourglass) + " \\$zGetting the list of recently played maps" + (m_MXIds.Length == 0 ? "..." : " - " + m_MXIds.Length + " maps found"));
         UI::Text((m_migrationStep > 1 ? "\\$090" + Icons::Check : "\\$f80" + Hourglass) + " \\$zGetting the missing data from the API" + (m_MapsFetched.Length == 0 ? "..." : " - " + m_MapsFetched.Length + "/"+m_MXIds.Length + " maps"));
         UI::Text(migrationCompleted ? "\\$090" + Icons::Check + " \\$zData migration completed!" : "\\$f80" + Hourglass  + " \\$zMigrating data...");
 
         switch (m_migrationStep) {
             case 0:
+                if (createBackup) Migration::BackupData();
+
                 m_MXIds = Migration::GetMX1MapsId();
                 if (m_MXIds.Length == 0) m_migrationStep = 2;
                 else m_migrationStep++;
@@ -85,6 +89,7 @@ class MX2MigrationWizardModalDialog : ModalDialog
             UI::Separator();
             UI::NewLine();
             UI::TextWrapped("\\$0f0" + Icons::Check + " \\$zYour data has been successfully migrated to ManiaExchange 2.0.");
+            if (createBackup) UI::TextWrapped(Icons::Kenney::Save + " You can find your backup at " + MX_V1_BACKUP_LOCATION);
         }
         UI::NewLine();
         if (m_MapsFetched.Length > 0 && UI::TreeNode("Saved maps")){
@@ -119,7 +124,10 @@ class MX2MigrationWizardModalDialog : ModalDialog
             }
             UI::SameLine();
             vec2 currentPos = UI::GetCursorPos();
-            UI::SetCursorPos(vec2(UI::GetWindowSize().x - 90 * scale, currentPos.y));
+            UI::SetCursorPos(vec2(UI::GetWindowSize().x - 230 * scale, currentPos.y));
+            createBackup = UI::Checkbox("Back up old data", createBackup);
+            UI::SetItemTooltip("If enabled, the old data will be backed up in another folder.\n\nUseful if you want to use an old version of the plugin.");
+            UI::SameLine();
             if (UI::GreenButton("Migrate " + Icons::ArrowRight)) {
                 m_stage++;
             }

--- a/src/Interface/ModalDialogs/MX2MigrationWizardModalDialog.as
+++ b/src/Interface/ModalDialogs/MX2MigrationWizardModalDialog.as
@@ -1,0 +1,132 @@
+class MX2MigrationWizardModalDialog : ModalDialog
+{
+    int m_stage = 0;
+    int m_migrationStep = 0;
+    bool migrationCompleted = false;
+    array<int> m_MXIds;
+    array<MX::MapInfo@> m_MapsFetched;
+
+    MX2MigrationWizardModalDialog()
+    {
+        super(MX_COLOR_STR + Icons::Random + " \\$zMX 2.0 Migration Wizard");
+        m_size = vec2(Draw::GetWidth() / 3, Draw::GetHeight() / 3);
+    }
+
+    void RenderStep1()
+    {
+        UI::PushFont(g_fontHeader);
+        UI::TextWrapped("Thanks for updating " + PLUGIN_NAME +"!");
+        UI::PopFont();
+
+        UI::TextWrapped("This wizard will help you migrate your data to ManiaExchange 2.0.");
+        UI::NewLine();
+        UI::TextWrapped(
+            "The new version of the plugin adds support to the new ManiaExchange. "
+            "This means that you will need to migrate your data and saves to support it."
+        );
+        UI::NewLine();
+
+        UI::TextWrapped(
+            "The migration process will take a few seconds depending on your recently played maps list and saved runs."
+        );
+
+        UI::NewLine();
+        UI::Separator();
+        UI::NewLine();
+        UI::TextWrapped(
+            "To start the migration, select the \"Migrate\" button below.\n\n"
+            "If you want to skip this process instead, select the \"Skip\" button "
+            "(but all your data will be deleted)."
+        );
+    }
+
+    void RenderStep2()
+    {
+        int HourGlassValue = Time::Stamp % 3;
+        string Hourglass = (HourGlassValue == 0 ? Icons::HourglassStart : (HourGlassValue == 1 ? Icons::HourglassHalf : Icons::HourglassEnd));
+
+        UI::PushFont(g_fontHeader);
+        if (!migrationCompleted) UI::Text("Please wait...");
+        else UI::Text("Data migration complete!");
+        UI::PopFont();
+        UI::NewLine();
+
+        UI::Text((m_migrationStep > 0 ? "\\$090" + Icons::Check : "\\$f80" + Hourglass) + " \\$zGetting the list of recently played maps" + (m_MXIds.Length == 0 ? "..." : " - " + m_MXIds.Length + " maps found"));
+        UI::Text((m_migrationStep > 1 ? "\\$090" + Icons::Check : "\\$f80" + Hourglass) + " \\$zGetting the missing data from the API" + (m_MapsFetched.Length == 0 ? "..." : " - " + m_MapsFetched.Length + "/"+m_MXIds.Length + " maps"));
+        UI::Text(migrationCompleted ? "\\$090" + Icons::Check + " \\$zData migration completed!" : "\\$f80" + Hourglass  + " \\$zMigrating data...");
+
+        switch (m_migrationStep) {
+            case 0:
+                m_MXIds = Migration::GetMX1MapsId();
+                if (m_MXIds.Length == 0) m_migrationStep = 2;
+                else m_migrationStep++;
+                break;
+            case 1:
+                Migration::CheckMX2MigrationRequest();
+                if (Migration::v2_request is null) {
+                    if (Migration::v2_maps.Length == 0) {
+                        Migration::StartMX2RequestMapsInfo(m_MXIds);
+                    } else {
+                        m_MapsFetched = Migration::v2_maps;
+                        m_migrationStep++;
+                    }
+                }
+                break;
+            case 2:
+                if (m_MapsFetched.Length > 0 && !migrationCompleted) {
+                    Migration::UpdateData();
+                }
+                migrationCompleted = true;
+                break;
+        }
+
+        if (migrationCompleted) {
+            UI::NewLine();
+            UI::Separator();
+            UI::NewLine();
+            UI::TextWrapped("\\$0f0" + Icons::Check + " \\$zYour data has been successfully migrated to ManiaExchange 2.0.");
+        }
+        UI::NewLine();
+        if (m_MapsFetched.Length > 0 && UI::TreeNode("Saved maps")){
+            for (uint i = 0; i < m_MapsFetched.Length; i++){
+                UI::Text(m_MapsFetched[i].MapId + ": " + m_MapsFetched[i].Name + " - " + m_MapsFetched[i].Username);
+                if (UI::IsItemClicked()) OpenBrowserURL("https://"+MX_URL+"/mapshow/"+m_MapsFetched[i].MapId);
+            }
+            UI::TreePop();
+        }
+    }
+
+    bool CanClose() override
+    {
+        return migrationCompleted;
+    }
+
+    void RenderDialog() override
+    {
+        float scale = UI::GetScale();
+        UI::BeginChild("Content", vec2(0, -32) * scale);
+        switch (m_stage) {
+            case 0: RenderStep1(); break;
+            case 1: RenderStep2(); break;
+        }
+        UI::EndChild();
+
+        if (m_stage == 0) {
+            if (UI::RedButton(Icons::Times + " Skip")) {
+                DataManager::InitData();
+                Migration::RemoveMX1SaveFiles();
+                Close();
+            }
+            UI::SameLine();
+            vec2 currentPos = UI::GetCursorPos();
+            UI::SetCursorPos(vec2(UI::GetWindowSize().x - 90 * scale, currentPos.y));
+            if (UI::GreenButton("Migrate " + Icons::ArrowRight)) {
+                m_stage++;
+            }
+        }
+
+        if (migrationCompleted && UI::GreenButton(Icons::Check + "Finish")) {
+            Close();
+        }
+    }
+}

--- a/src/Interface/Renders/RecentlyMapsList.as
+++ b/src/Interface/Renders/RecentlyMapsList.as
@@ -32,9 +32,9 @@ namespace Render
 
                 if (UI::ButtonColored(Icons::ExternalLink, 0.55, 1, 0.5)) {
 #if DEPENDENCY_MANIAEXCHANGE
-                    ManiaExchange::ShowMapInfo(map.TrackID);
+                    ManiaExchange::ShowMapInfo(map.MapId);
 #else
-                    OpenBrowserURL("https://"+MX_URL+"/maps/"+map.TrackID);
+                    OpenBrowserURL("https://"+MX_URL+"/maps/"+map.MapId);
 #endif
                 }
                 UI::SameLine();
@@ -45,7 +45,7 @@ namespace Render
 #else
                 if (TM::CurrentTitlePack() == map.TitlePack && UI::GreenButton(Icons::Play)) {
 #endif
-                    TM::loadMapURL = PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID;
+                    TM::loadMapURL = PluginSettings::RMC_MX_Url+"/maps/download/"+map.MapId;
                     startnew(TM::LoadMap);
                 }
 

--- a/src/Interface/Renders/RecentlyMapsList.as
+++ b/src/Interface/Renders/RecentlyMapsList.as
@@ -34,7 +34,7 @@ namespace Render
 #if DEPENDENCY_MANIAEXCHANGE
                     ManiaExchange::ShowMapInfo(map.MapId);
 #else
-                    OpenBrowserURL("https://"+MX_URL+"/maps/"+map.MapId);
+                    OpenBrowserURL("https://"+MX_URL+"/mapshow/"+map.MapId);
 #endif
                 }
                 UI::SameLine();
@@ -45,7 +45,7 @@ namespace Render
 #else
                 if (TM::CurrentTitlePack() == map.TitlePack && UI::GreenButton(Icons::Play)) {
 #endif
-                    TM::loadMapURL = PluginSettings::RMC_MX_Url+"/maps/download/"+map.MapId;
+                    TM::loadMapURL = PluginSettings::RMC_MX_Url+"/mapgbx/"+map.MapId;
                     startnew(TM::LoadMap);
                 }
 

--- a/src/Interface/Renders/RecentlyMapsList.as
+++ b/src/Interface/Renders/RecentlyMapsList.as
@@ -15,7 +15,7 @@ namespace Render
                 UI::TableSetColumnIndex(1);
                 UI::Text(map.Username);
                 UI::TableSetColumnIndex(2);
-                if (map.PlayedAt.GetType() == Json::Type::Object) UI::Text(GeneratePlayedAtString(map.PlayedAt));
+                if (map.PlayedAt > 0) UI::Text(GeneratePlayedAtString(map.PlayedAt));
                 else {
                     UI::Text("Unknown");
                     UI::SetPreviousTooltip("Unable to parse date, maybe this map was migrated from old version.");
@@ -54,13 +54,7 @@ namespace Render
         }
     }
 
-    string GeneratePlayedAtString(Json::Value playedAt){
-        int playedAtYear = playedAt["Year"];
-        int playedAtMonth = playedAt["Month"];
-        int playedAtDay = playedAt["Day"];
-        int playedAtHour = playedAt["Hour"];
-        int playedAtMinute = playedAt["Minute"];
-        int playedAtSecond = playedAt["Second"];
-        return playedAtYear + "-" + (playedAtMonth < 10 ? "0":"") + playedAtMonth + "-" + (playedAtDay < 10 ? "0":"") + playedAtDay + " " + (playedAtHour < 10 ? "0":"") + playedAtHour + ":" + (playedAtMinute < 10 ? "0":"") + playedAtMinute + ":" + (playedAtSecond < 10 ? "0":"") + playedAtSecond;
+    string GeneratePlayedAtString(int stamp) {
+        return Time::FormatString("%F %T", stamp);
     }
 }

--- a/src/Main.as
+++ b/src/Main.as
@@ -70,6 +70,11 @@ void Main()
     @g_fontHeader = UI::LoadFont("DroidSans-Bold.ttf", 22);
     @g_fontHeaderSub = UI::LoadFont("DroidSans.ttf", 20);
 
+    DataManager::EnsureSaveFileFolderPresent();
+
+    Meta::PluginCoroutine@ tagLoad = startnew(MX::FetchMapTags);
+    await(tagLoad);
+
     if (DataJson.GetType() == Json::Type::Null) {
         if (DataJsonFromDataFolder.GetType() != Json::Type::Null) {
             DataManager::InitData(false);
@@ -105,8 +110,6 @@ void Main()
             }
         }
     }
-    DataManager::EnsureSaveFileFolderPresent();
-    MX::FetchMapTags();
     RMC::FetchConfig();
     RMC::InitModes();
 #if DEPENDENCY_NADEOSERVICES

--- a/src/Main.as
+++ b/src/Main.as
@@ -85,25 +85,27 @@ void Main()
                 Renderables::Add(DataMigrationWizardModalDialog());
             }
         }
+
+        // Migration is not needed
+        Migration::MigratedToMX2 = true;
     } else {
         DataManager::CheckData();
+
+        if (!Migration::MigratedToMX2) {
+            Migration::MigrateMX1Settings();
+            MX2MigrationWizardModalDialog migrationDialog = MX2MigrationWizardModalDialog();
+            Renderables::Add(migrationDialog);
+
+            while (!migrationDialog.migrationCompleted && !Migration::v2_requestError) {
+                yield();
+            }
+
+            if (migrationDialog.migrationCompleted) {
+                Migration::MigratedToMX2 = true;
+            }
+        }
     }
     DataManager::EnsureSaveFileFolderPresent();
-
-    if (!Migration::MigratedToMX2) {
-        Migration::MigrateMX1Settings();
-        MX2MigrationWizardModalDialog migrationDialog = MX2MigrationWizardModalDialog();
-        Renderables::Add(migrationDialog);
-
-        while (!migrationDialog.migrationCompleted && !Migration::v2_requestError) {
-            yield();
-        }
-
-        if (migrationDialog.migrationCompleted) {
-            Migration::MigratedToMX2 = true;
-        }
-    }
-
     MX::FetchMapTags();
     RMC::FetchConfig();
     RMC::InitModes();

--- a/src/Main.as
+++ b/src/Main.as
@@ -92,9 +92,16 @@ void Main()
 
     if (!Migration::MigratedToMX2) {
         Migration::MigrateMX1Settings();
-        Renderables::Add(MX2MigrationWizardModalDialog());
+        MX2MigrationWizardModalDialog migrationDialog = MX2MigrationWizardModalDialog();
+        Renderables::Add(migrationDialog);
 
-        Migration::MigratedToMX2 = true;
+        while (!migrationDialog.migrationCompleted && !Migration::v2_requestError) {
+            yield();
+        }
+
+        if (migrationDialog.migrationCompleted) {
+            Migration::MigratedToMX2 = true;
+        }
     }
 
     MX::FetchMapTags();

--- a/src/Main.as
+++ b/src/Main.as
@@ -89,6 +89,14 @@ void Main()
         DataManager::CheckData();
     }
     DataManager::EnsureSaveFileFolderPresent();
+
+    if (!Migration::MigratedToMX2) {
+        Migration::MigrateMX1Settings();
+        Renderables::Add(MX2MigrationWizardModalDialog());
+
+        Migration::MigratedToMX2 = true;
+    }
+
     MX::FetchMapTags();
     RMC::FetchConfig();
     RMC::InitModes();

--- a/src/Settings/About.as
+++ b/src/Settings/About.as
@@ -60,9 +60,9 @@ void RenderAboutTab()
     UI::PushFont(g_fontHeaderSub);
     UI::Text("ManiaExchange");
     UI::PopFont();
-    if (UI::Button(Icons::KeyboardO + " \\$zContact ManiaExchange")) OpenBrowserURL("https://"+MX_URL+"/messaging/compose/11");
+    if (UI::Button(Icons::KeyboardO + " \\$zContact ManiaExchange")) OpenBrowserURL("https://"+MX_URL+"/postcreate?PmTargetUserId=11");
     UI::SameLine();
-    if (UI::RedButton(Icons::Heart + " \\$zSupport ManiaExchange")) OpenBrowserURL("https://"+MX_URL+"/support");
+    if (UI::RedButton(Icons::Heart + " \\$zSupport ManiaExchange")) OpenBrowserURL("https://"+MX_URL+"/about?r=support");
 
     UI::Text("Base URL \\$777" + PluginSettings::RMC_MX_Url);
 

--- a/src/Settings/AdvancedParameters.as
+++ b/src/Settings/AdvancedParameters.as
@@ -4,11 +4,7 @@ namespace PluginSettings
     bool closeOverlayOnMapLoaded = true;
 
     [Setting hidden]
-#if TMNEXT
-    string RMC_MX_Url = "https://map-monitor.xk.io";
-#else
     string RMC_MX_Url = "https://" + MX_URL;
-#endif
 
     [Setting hidden]
     string RMC_Leaderboard_Url = "https://flinkblog.de/RMC";
@@ -48,12 +44,6 @@ namespace PluginSettings
         // if (clickedDanApi) {
         //     RMC_MX_Url = "https://mx.danonthemoon.dev/mx";
         // }
-
-        bool clickedXertApi = UI::Button("Use XertroV's API w/ Fixed Randomization");
-        UI::SetPreviousTooltip("Much faster random API for TMX maps, and fixes TMX's broken randomization.\nAll TMX maps are cached and standard RMC map filtering applies.");
-        if (clickedXertApi) {
-            RMC_MX_Url = "https://map-monitor.xk.io";
-        }
 
         if (PluginSettings::RMC_PushLeaderboardResults) {
             UI::NewLine();

--- a/src/Settings/AdvancedParameters.as
+++ b/src/Settings/AdvancedParameters.as
@@ -9,10 +9,6 @@ namespace PluginSettings
     [Setting hidden]
     string RMC_Leaderboard_Url = "https://flinkblog.de/RMC";
 
-    // add a setting that people can toggle to switch between to the old length checks and manual length checks, in case the API starts failing.
-    [Setting hidden]
-    bool UseLengthChecksInRequests = true;
-
     [SettingsTab name="Advanced" order="3" icon="Wrench"]
     void RenderAdvancedSettings()
     {
@@ -21,7 +17,6 @@ namespace PluginSettings
             closeOverlayOnMapLoaded = true;
             RMC_MX_Url = "https://" + MX_URL;
             RMC_Leaderboard_Url = "https://flinkblog.de/RMC";
-            UseLengthChecksInRequests = true;
         }
 
         UI::SetNextItemWidth(300);
@@ -60,8 +55,5 @@ namespace PluginSettings
 #endif
 
         closeOverlayOnMapLoaded = UI::Checkbox("Close overlay on map loading", closeOverlayOnMapLoaded);
-
-        UseLengthChecksInRequests = UI::Checkbox("Use length filters in API requests", UseLengthChecksInRequests);
-        UI::SetPreviousTooltip("Length filter setting. Toggle this when TMX gives super long response times.");
     }
 }

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -29,8 +29,7 @@ namespace PluginSettings
         "3 minutes and 30 seconds",
         "4 minutes",
         "4 minutes and 30 seconds",
-        "5 minutes",
-        "Longer than 5 minutes"
+        "5 minutes"
     };
 
     const array<int> SearchingMapLengthsMilliseconds = {
@@ -48,8 +47,7 @@ namespace PluginSettings
         210000,
         240000,
         270000,
-        300000,
-        100000000,  // infinity, I guess.
+        300000
     };
 
     array<string> MapAuthorNamesArr = {};

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -229,6 +229,7 @@ namespace PluginSettings
         // Using InputText instead of a InputInt because it looks better and using "" as empty value instead of 0 for consistency with the other fields
         UI::SetNextItemWidth(200);
         MapAuthor = UI::InputText("Map Author(s) Filter", MapAuthor, false);
+        if (MapAuthor.Contains(",")) UI::TextWrapped("\\$f90" + Icons::ExclamationTriangle + " \\$z MX 2.0 doesn't support searching multiple authors yet. Only the first one will be included.");
         UI::NewLine();
 
         MapAuthorNamesArr = ConvertStringToArray(MapAuthor);

--- a/src/Settings/SearchingParameters.as
+++ b/src/Settings/SearchingParameters.as
@@ -67,9 +67,6 @@ namespace PluginSettings
     string MapAuthor = "";
 
     [Setting hidden]
-    bool MapAuthorNameNeedsExactMatch = true;
-
-    [Setting hidden]
     string MapName = "";
     
     [Setting hidden]
@@ -155,7 +152,6 @@ namespace PluginSettings
             MapPackID = 0;
             MapTagsArr = {};
             MapAuthorNamesArr = {};
-            MapAuthorNameNeedsExactMatch = true;
 #if TMNEXT
             ExcludeMapTagsArr = {23, 37, 40};
 #else
@@ -235,9 +231,6 @@ namespace PluginSettings
         // Using InputText instead of a InputInt because it looks better and using "" as empty value instead of 0 for consistency with the other fields
         UI::SetNextItemWidth(200);
         MapAuthor = UI::InputText("Map Author(s) Filter", MapAuthor, false);
-        UI::SameLine();
-        MapAuthorNameNeedsExactMatch = UI::Checkbox("Exact name matches", MapAuthorNameNeedsExactMatch);
-        UI::SetPreviousTooltip("If disabled, you will get results for any author that contains the text you entered.\nIf you search for \"Nadeo\", you will get results for \"Nadeo\", \"Nadeo123\", \"Nadeo_\", etc.\nIf enabled, you will only get results for \"Nadeo\".\nHowever this can lead to issues if the author has changed their MX username since uploading the map. This can be avoided by specifying all the names the author has used.");
         UI::NewLine();
 
         MapAuthorNamesArr = ConvertStringToArray(MapAuthor);

--- a/src/Utils/Dates.as
+++ b/src/Utils/Dates.as
@@ -17,6 +17,10 @@ class Date
     bool isAfter(const Date@ &in date) {
         return !isBefore(date);
     }
+
+    string ToString() {
+        return year + "-" + Text::Format("%.02d", month) + "-" + Text::Format("%.02d", day);
+    }
 }
 
 SQLite::Database@ cursedTimeDB = SQLite::Database(":memory:");

--- a/src/Utils/Dates.as
+++ b/src/Utils/Dates.as
@@ -22,13 +22,3 @@ class Date
         return year + "-" + Text::Format("%.02d", month) + "-" + Text::Format("%.02d", day);
     }
 }
-
-SQLite::Database@ cursedTimeDB = SQLite::Database(":memory:");
-int64 DateFromStrTime(const string &in inTime) {
-    auto st = cursedTimeDB.Prepare("SELECT unixepoch(?) as x");
-    st.Bind(1, inTime);
-    st.Execute();
-    st.NextRow();
-    st.NextRow();
-    return st.GetColumnInt64("x");
-}

--- a/src/Utils/Dates.as
+++ b/src/Utils/Dates.as
@@ -22,3 +22,15 @@ class Date
         return year + "-" + Text::Format("%.02d", month) + "-" + Text::Format("%.02d", day);
     }
 }
+
+int TimestampFromObject(Json::Value@ obj) {
+    string year = tostring(int(obj["Year"]));
+    string month = Text::Format("%02d", int(obj["Month"]));
+    string day = Text::Format("%02d", int(obj["Day"]));
+    string hour = Text::Format("%02d", int(obj["Hour"]));
+    string minute = Text::Format("%02d", int(obj["Minute"]));
+    string second = Text::Format("%02d", int(obj["Second"]));
+    
+    string date = year + "-" + month + "-" + day + " " + hour + ":" + minute + ":" + second;
+    return Time::ParseFormatString('%F %T', date);
+}

--- a/src/Utils/Logging.as
+++ b/src/Utils/Logging.as
@@ -40,7 +40,7 @@ namespace Log
 
     void LoadingMapNotification(MX::MapInfo@ map)
     {
-        Log("Loading map: " + map.Name + " (" + map.TrackID + ")");
+        Log("Loading map: " + map.Name + " (" + map.MapId + ")");
         vec4 color = UI::HSV(0.25, 1, 0.7);
         UI::ShowNotification(Icons::Kenney::ReloadInverse + " Loading map", map.Name + "\nby: "+map.Username, color, 5000);
     }

--- a/src/Utils/MX/Entities/MapInfo.as
+++ b/src/Utils/MX/Entities/MapInfo.as
@@ -31,7 +31,7 @@ namespace MX
                 MapType = json["MapType"];
                 ExeBuild = json["Exebuild"];
                 UploadedAt = json["UploadedAt"];
-                if (json["PlayedAt"].GetType() != Json::Type::Null) PlayedAt = json["PlayedAt"];
+                if (json.HasKey("PlayedAt") && json["PlayedAt"].GetType() != Json::Type::Null) PlayedAt = json["PlayedAt"];
                 if (json["GbxMapName"].GetType() != Json::Type::Null) GbxMapName = json["GbxMapName"];
                 if (json["TitlePack"].GetType() != Json::Type::Null) TitlePack = json["TitlePack"];
                 AwardCount = json["AwardCount"];

--- a/src/Utils/MX/Entities/MapInfo.as
+++ b/src/Utils/MX/Entities/MapInfo.as
@@ -11,7 +11,7 @@ namespace MX
         string ExeBuild;
         string UploadedAt;
         string UpdatedAt;
-        Json::Value PlayedAt;
+        int PlayedAt;
         string Name;
         string GbxMapName;
         string TitlePack;
@@ -31,11 +31,13 @@ namespace MX
                 MapType = json["MapType"];
                 ExeBuild = json["Exebuild"];
                 UploadedAt = json["UploadedAt"];
-                if (json.HasKey("PlayedAt") && json["PlayedAt"].GetType() != Json::Type::Null) PlayedAt = json["PlayedAt"];
                 if (json["GbxMapName"].GetType() != Json::Type::Null) GbxMapName = json["GbxMapName"];
                 if (json["TitlePack"].GetType() != Json::Type::Null) TitlePack = json["TitlePack"];
                 AwardCount = json["AwardCount"];
                 ServerSizeExceeded = json["ServerSizeExceeded"];
+
+                if (json.HasKey("PlayedAt") && json["PlayedAt"].GetType() != Json::Type::Null) PlayedAt = json["PlayedAt"];
+                else PlayedAt = Time::Stamp;
 
                 if (json["UpdatedAt"].GetType() != Json::Type::Null) {
                     UpdatedAt = json["UpdatedAt"];

--- a/src/Utils/MX/Entities/MapInfo.as
+++ b/src/Utils/MX/Entities/MapInfo.as
@@ -2,11 +2,11 @@ namespace MX
 {
     class MapInfo
     {
-        int TrackID;
-        string TrackUID;
-        int UserID;
+        int MapId;
+        string MapUid;
+        string OnlineMapId;
+        int UserId;
         string Username;
-        string AuthorLogin;
         string MapType;
         string ExeBuild;
         string UploadedAt;
@@ -14,65 +14,57 @@ namespace MX
         Json::Value PlayedAt;
         string Name;
         string GbxMapName;
-        string Comments;
         string TitlePack;
-        bool Unlisted;
-        string Mood;
-        int DisplayCost;
-        string LengthName;
-        int Laps;
-        string DifficultyName;
-        string VehicleName;
         int AuthorTime;
-        int TrackValue;
         int AwardCount;
-        uint ImageCount;
-        bool IsMP4;
+        int Length;
+        bool ServerSizeExceeded;
         array<MapTag@> Tags;
 
         MapInfo(const Json::Value &in json)
         {
             try {
-                TrackID = json["TrackID"];
-                TrackUID = json["TrackUID"];
-                UserID = json["UserID"];
-                Username = json["Username"];
-                AuthorLogin = json["AuthorLogin"];
-                MapType = json["MapType"];
-                ExeBuild = json["ExeBuild"];
-                UploadedAt = json["UploadedAt"];
-                UpdatedAt = json["UpdatedAt"];
-                if (json["PlayedAt"].GetType() != Json::Type::Null) PlayedAt = json["PlayedAt"];
+                MapId = json["MapId"];
+                MapUid = json["MapUid"];
+                if (json["OnlineMapId"].GetType() != Json::Type::Null) OnlineMapId = json["OnlineMapId"];
                 Name = json["Name"];
-                GbxMapName = json["GbxMapName"];
-                Comments = json["Comments"];
+                MapType = json["MapType"];
+                ExeBuild = json["Exebuild"];
+                UploadedAt = json["UploadedAt"];
+                if (json["PlayedAt"].GetType() != Json::Type::Null) PlayedAt = json["PlayedAt"];
+                if (json["GbxMapName"].GetType() != Json::Type::Null) GbxMapName = json["GbxMapName"];
                 if (json["TitlePack"].GetType() != Json::Type::Null) TitlePack = json["TitlePack"];
-                Unlisted = json["Unlisted"];
-                Mood = json["Mood"];
-                DisplayCost = json["DisplayCost"];
-                if (json["LengthName"].GetType() != Json::Type::Null) LengthName = json["LengthName"];
-                Laps = json["Laps"];
-                if (json["DifficultyName"].GetType() != Json::Type::Null) DifficultyName = json["DifficultyName"];
-                if (json["VehicleName"].GetType() != Json::Type::Null) VehicleName = json["VehicleName"];
-                if (json["AuthorTime"].GetType() != Json::Type::Null) AuthorTime = json["AuthorTime"];
-                TrackValue = json["TrackValue"];
                 AwardCount = json["AwardCount"];
-                ImageCount = json["ImageCount"];
-                IsMP4 = json["IsMP4"];
+                ServerSizeExceeded = json["ServerSizeExceeded"];
 
-                // Tags is a string of ids separated by commas
-                // gets the ids and fetches the tags from m_mapTags
-                if (json["Tags"].GetType() != Json::Type::Null)
-                {
-                    string tagIds = json["Tags"];
-                    string[] tagIdsSplit = tagIds.Split(",");
-                    for (uint i = 0; i < tagIdsSplit.Length; i++)
-                    {
-                        int tagId = Text::ParseInt(tagIdsSplit[i]);
-                        for (uint j = 0; j < m_mapTags.Length; j++)
-                        {
-                            if (m_mapTags[j].ID == tagId)
-                            {
+                if (json["UpdatedAt"].GetType() != Json::Type::Null) {
+                    UpdatedAt = json["UpdatedAt"];
+                } else {
+                    UpdatedAt = json["UploadedAt"];
+                }
+
+                if (json["Uploader"].GetType() != Json::Type::Null) {
+                    UserId = json["Uploader"]["UserId"];
+                    Username = json["Uploader"]["Name"];
+                }
+
+                if (json["Medals"].GetType() != Json::Type::Null) {
+                    AuthorTime = json["Medals"]["Author"];
+                }
+
+                if (json["Length"].GetType() != Json::Type::Null) {
+                    Length = json["Length"];
+                } else {
+                    Length = AuthorTime;
+                }
+
+                // Tags is an array of tag objects
+                if (json["Tags"].GetType() != Json::Type::Null) {
+                    const Json::Value@ tagObjects = json["Tags"];
+
+                    for (uint i = 0; i < tagObjects.Length; i++) {
+                        for (uint j = 0; j < m_mapTags.Length; j++) {
+                            if (m_mapTags[j].ID == tagObjects[i]["TagId"]) {
                                 Tags.InsertLast(m_mapTags[j]);
                                 break;
                             }
@@ -89,40 +81,38 @@ namespace MX
         {
             Json::Value json = Json::Object();
             try {
-                json["TrackID"] = TrackID;
-                json["TrackUID"] = TrackUID;
-                json["UserID"] = UserID;
-                json["Username"] = Username;
-                json["AuthorLogin"] = AuthorLogin;
+                json["MapId"] = MapId;
+                json["MapUid"] = MapUid;
+                json["OnlineMapId"] = OnlineMapId;
+                json["Name"] = Name;
                 json["MapType"] = MapType;
-                json["ExeBuild"] = ExeBuild;
+                json["Exebuild"] = ExeBuild;
                 json["UploadedAt"] = UploadedAt;
                 json["UpdatedAt"] = UpdatedAt;
                 json["PlayedAt"] = PlayedAt;
-                json["Name"] = Name;
                 json["GbxMapName"] = GbxMapName;
-                json["Comments"] = Comments;
                 json["TitlePack"] = TitlePack;
-                json["Unlisted"] = Unlisted;
-                json["Mood"] = Mood;
-                json["DisplayCost"] = DisplayCost;
-                json["LengthName"] = LengthName;
-                json["Laps"] = Laps;
-                json["DifficultyName"] = DifficultyName;
-                json["VehicleName"] = VehicleName;
-                json["AuthorTime"] = AuthorTime;
-                json["TrackValue"] = TrackValue;
                 json["AwardCount"] = AwardCount;
-                json["ImageCount"] = ImageCount;
-                json["IsMP4"] = IsMP4;
+                json["ServerSizeExceeded"] = ServerSizeExceeded;
+                json["Length"] = Length;
 
-                string tagsStr = "";
-                for (uint i = 0; i < Tags.Length; i++)
-                {
-                    tagsStr += tostring(Tags[i].ID);
-                    if (i < Tags.Length - 1) tagsStr += ",";
+                Json::Value uploaderObject = Json::Object();
+                uploaderObject["UserId"] = UserId;
+                uploaderObject["Name"] = Username;
+
+                json["Uploader"] = uploaderObject;
+
+                Json::Value medalsObject = Json::Object();
+                medalsObject["Author"] = AuthorTime;
+
+                json["Medals"] = medalsObject;
+
+                Json::Value tagArray = Json::Array();
+                for (uint i = 0; i < Tags.Length; i++) {
+                    tagArray.Add(Tags[i].ToJson());
                 }
-                json["Tags"] = tagsStr;
+
+                json["Tags"] = tagArray;
             } catch {
                 Log::Error("Error converting map info to JSON for map "+Name, true);
             }

--- a/src/Utils/MX/Entities/MapTag.as
+++ b/src/Utils/MX/Entities/MapTag.as
@@ -17,5 +17,19 @@ namespace MX
                 Log::Warn("Error parsing tag: "+Name);
             }
         }
+
+        Json::Value ToJson()
+        {
+            Json::Value json = Json::Object();
+            try {
+                json["TagId"] = ID;
+                json["Name"] = Name;
+                json["Color"] = Color;
+            } catch {
+                Log::Warn("Error converting tag info to json for tag " + Name);
+            }
+
+            return json;
+        }
     }
 }

--- a/src/Utils/MX/Methods/DownloadMap.as
+++ b/src/Utils/MX/Methods/DownloadMap.as
@@ -20,7 +20,7 @@ namespace MX
                 yield();
             }
 
-            if (_fileName.Length > 0) _fileName = map.TrackID + " - " + map.Name;
+            if (_fileName.Length > 0) _fileName = map.MapId + " - " + map.Name;
             netMap.SaveToFile(mxDLFolder + "/" + _fileName + ".Map.Gbx");
             Log::Log("Map downloaded to " + mxDLFolder + "/" + _fileName + ".Map.Gbx");
         } catch {

--- a/src/Utils/MX/Methods/DownloadMap.as
+++ b/src/Utils/MX/Methods/DownloadMap.as
@@ -2,7 +2,7 @@ namespace MX
 {
     void DownloadMap(const int &in mapId, string _fileName = "") {
         try {
-            auto json = API::GetAsync(PluginSettings::RMC_MX_Url+"/api/maps/get_map_info/multi/"+mapId);
+            auto json = API::GetAsync(PluginSettings::RMC_MX_Url+"/api/maps?fields"+MAP_FIELDS+"&id="+mapId);
             if (json.Length == 0) {
                 Log::Error("Track not found.", true);
                 return;
@@ -14,7 +14,7 @@ namespace MX
             if (!IO::FolderExists(downloadedMapFolder)) IO::CreateFolder(downloadedMapFolder);
             if (!IO::FolderExists(mxDLFolder)) IO::CreateFolder(mxDLFolder);
 
-            Net::HttpRequest@ netMap = API::Get(PluginSettings::RMC_MX_Url+"/maps/download/"+mapId);
+            Net::HttpRequest@ netMap = API::Get(PluginSettings::RMC_MX_Url+"/mapgbx/"+mapId);
             Log::Trace("Started downloading map "+map.Name+" ("+mapId+") to "+mxDLFolder);
             while(!netMap.Finished()) {
                 yield();

--- a/src/Utils/MX/Methods/FetchMapTags.as
+++ b/src/Utils/MX/Methods/FetchMapTags.as
@@ -5,7 +5,7 @@ namespace MX
         m_mapTags.RemoveRange(0, m_mapTags.Length);
         APIRefreshing = true;
 
-        Json::Value resNet = API::GetAsync(PluginSettings::RMC_MX_Url+"/api/tags/gettags");
+        Json::Value resNet = API::GetAsync(PluginSettings::RMC_MX_Url+"/api/meta/tags");
 
         try {
             for (uint i = 0; i < resNet.Length; i++)

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -113,6 +113,7 @@ namespace MX
                 }
             } else {
                 Log::Error("ManiaExchange API returned an error, retrying...");
+                sleep(3000);
                 PreloadRandomMap();
                 return;
             }

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -4,56 +4,70 @@ namespace MX
     bool isLoadingPreload = false;
 
     Json::Value CheckCustomRulesParametersNoResults() {
-        // for some reason if we use random it *always* returns a webpage instead of an actual dict response if no items are found. It also sometimes does not find any items even though there are some.
-        // So we have to use a non-random API call which then gives us a dict from which we can check if any item would exist with the specified parameters.
-        string check_url = PluginSettings::RMC_MX_Url + "/mapsearch2/search?api=on&limit=1";
+        string check_url = PluginSettings::RMC_MX_Url + "/api/maps";
+
+        dictionary params;
+        params.Set("fields", MAP_FIELDS);
+        params.Set("random", "1");
+        params.Set("count", "1");
+        params.Set("maptype", SUPPORTED_MAP_TYPE); // ignore any non-Race maps (Royal, flagrush etc...)
+
 #if TMNEXT
         // ignore CharacterPilot maps
-        check_url += "&vehicles=1";
+        params.Set("vehicle", "1,2,3,4");
 #elif MP4
         // only consider the correct titlepack
-        if (TM::CurrentTitlePack() == "TMAll") {
-            check_url += "&tpack=" + TM::CurrentTitlePack()+"&tpack=TMCanyon&tpack=TMValley&tpack=TMStadium&tpack=TMLagoon";
+        if (TM::CurrentTitlePack() == "TMAll" && false) {
+            params.Set("titlepack", TM::CurrentTitlePack() + ",TMCanyon,TMValley,TMStadium,TMLagoon"); // TODO doesn't work yet
         } else {
-            check_url += "&tpack=" + TM::CurrentTitlePack();
+            params.Set("titlepack", TM::CurrentTitlePack());
         }
 #endif
-        // ignore any non-Race maps (Royal, flagrush etc...)
-        check_url += "&mtype="+SUPPORTED_MAP_TYPE;
+
         if (PluginSettings::MapAuthor != "") {
-            Json::Value _res = API::GetAsync(check_url + "&author=" + Net::UrlEncode(PluginSettings::MapAuthor));
-            if (_res["totalItemCount"] == 0) {
+            params.Set("author", Net::UrlEncode(PluginSettings::MapAuthor));
+            string urlParams = DictToApiParams(params);
+
+            Json::Value _res = API::GetAsync(check_url + urlParams);
+            if (_res["Results"].Length == 0) {
                 // author does not own any usable map.
                 Log::Error(Icons::ExclamationTriangle+" No maps found for author '"+PluginSettings::MapAuthor+"', retrying without author set...");
                 PluginSettings::MapAuthor = "";
                 return _res;
-            } else if (_res["totalItemCount"] == 1) {
+            } else if (_res["Results"].Length == 1) {
                 // author only has one usable map, so we can just return it as the API will troll when using random on it
-                return _res["results"][0];
+                return _res["Results"][0];
             }
         }
         if (PluginSettings::MapName != "") {
-            Json::Value _res = API::GetAsync(check_url + "&trackname=" + Net::UrlEncode(PluginSettings::MapName));
-            if (_res["totalItemCount"] == 0) {
+            params.Set("name", Net::UrlEncode(PluginSettings::MapName));
+            string urlParams = DictToApiParams(params);
+
+            Json::Value _res = API::GetAsync(check_url + urlParams);
+            if (_res["Results"].Length == 0) {
                 // there are no map names matching the filter
                 Log::Error(Icons::ExclamationTriangle+" No maps found for name '"+PluginSettings::MapName+"', retrying without name set...");
                 PluginSettings::MapName = "";
                 return _res;
-            } else if (_res["totalItemCount"] == 1) {
+            } else if (_res["Results"].Length == 1) {
                 // there is only one map matching the filter, so we can just return it
-                return _res["results"][0];
+                return _res["Results"][0];
             }
         }
         if (PluginSettings::MapAuthor != "" && PluginSettings::MapName != "") {
-            Json::Value _res = API::GetAsync(check_url + "&author=" + Net::UrlEncode(PluginSettings::MapAuthor) + "&trackname=" + Net::UrlEncode(PluginSettings::MapName));
-            if (_res["totalItemCount"] == 0) {
+            params.Set("name", Net::UrlEncode(PluginSettings::MapName));
+            params.Set("author", Net::UrlEncode(PluginSettings::MapAuthor));
+            string urlParams = DictToApiParams(params);
+
+            Json::Value _res = API::GetAsync(check_url + urlParams);
+            if (_res["Results"].Length == 0) {
                 // there are no map names matching the filter
                 Log::Error(Icons::ExclamationTriangle+" No maps found for author '"+PluginSettings::MapAuthor+"' and name '"+PluginSettings::MapName+"', retrying without name set...");
                 PluginSettings::MapName = "";
                 return _res;
-            } else if (_res["totalItemCount"] == 1) {
+            } else if (_res["Results"].Length == 1) {
                 // there is only one map matching the filter, so we can just return it
-                return _res["results"][0];
+                return _res["Results"][0];
             }
         }
 
@@ -77,7 +91,7 @@ namespace MX
         string URL = CreateQueryURL();
         Json::Value res;
         try {
-            res = API::GetAsync(URL)["results"][0];
+            res = API::GetAsync(URL)["Results"][0];
         } catch {
             if (PluginSettings::CustomRules || (!RMC::IsStarting && !RMC::IsRunning)) {
                 // we might get an error because the author doesn't have a map/no map with the given name exists
@@ -233,10 +247,10 @@ namespace MX
 #if DEPENDENCY_CHAOSMODE
             if (ChaosMode::IsInRMCMode()) {
                 Log::Trace("Loading map in Chaos Mode");
-                app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.MapId, "TrackMania/ChaosModeRMC", "");
+                app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/mapgbx/"+map.MapId, "TrackMania/ChaosModeRMC", "");
             } else
 #endif
-            app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.MapId, DEFAULT_MODE, "");
+            app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/mapgbx/"+map.MapId, DEFAULT_MODE, "");
             RMC::CurrentMapJsonData = map.ToJson();
         }
         catch
@@ -250,65 +264,83 @@ namespace MX
 
     string CreateQueryURL()
     {
-        string url = PluginSettings::RMC_MX_Url+"/mapsearch2/search?api=on&random=1";
+        string url = PluginSettings::RMC_MX_Url + "/api/maps";
+
+        dictionary params;
+        params.Set("fields", MAP_FIELDS);
+        params.Set("random", "1");
+        params.Set("count", "1");
 
         if ((RMC::IsRunning || RMC::IsStarting) && !PluginSettings::CustomRules)
         {
-            url += "&etags="+RMC::config.etags;
-            if (PluginSettings::UseLengthChecksInRequests) {
-                url += "&lengthop="+RMC::config.lengthop;
-                url += "&length="+RMC::config.length;
-            }
+            params.Set("etag", RMC::config.etags);
+            params.Set("authortimemax", tostring(RMC::allowedMaxLength));
         }
         else
-        {
-            if (PluginSettings::UseLengthChecksInRequests) {
-                if (PluginSettings::MapLengthOperator != "Exacts"){
-                    url += "&lengthop=" + PluginSettings::SearchingMapLengthOperators.Find(PluginSettings::MapLengthOperator);
-                }
-                if (PluginSettings::MapLength != "Anything"){
-                    url += "&length=" + (PluginSettings::SearchingMapLengths.Find(PluginSettings::MapLength)-1);
+        {		
+            if (PluginSettings::MapLength != "Anything") {
+                int minAuthor = GetMinimumLength();
+                int maxAuthor = GetMaxLength();
+
+                if (minAuthor != -1) params.Set("authortimemin", tostring(minAuthor));
+                if (maxAuthor != -1) params.Set("authortimemax", tostring(maxAuthor));
+            }
+            if (PluginSettings::UseDateInterval) {
+                Date@ afterDate = Date(PluginSettings::FromYear, PluginSettings::FromMonth, PluginSettings::FromDay);
+                Date@ beforeDate = Date(PluginSettings::ToYear, PluginSettings::ToMonth, PluginSettings::ToDay);
+
+                if (afterDate.isBefore(beforeDate)) {
+                    params.Set("uploadedafter", afterDate.ToString());
+                    params.Set("uploadedbefore", beforeDate.ToString());
+                } else {
+                    Log::Warn("Invalid date interval selected, ignoring...");
                 }
             }
             if (!PluginSettings::MapTagsArr.IsEmpty()){
-                url += "&tags=" + PluginSettings::MapTags;
+                params.Set("tag", PluginSettings::MapTags);
             }
             if (!PluginSettings::ExcludeMapTagsArr.IsEmpty()){
-                url += "&etags=" + PluginSettings::ExcludeMapTags;
+                params.Set("etag", PluginSettings::ExcludeMapTags);
             }
             if (PluginSettings::TagInclusiveSearch){
-                url += "&tagsinc=1";
+                params.Set("taginclusive", "1");
             }
             if (PluginSettings::Difficulty != "Anything"){
-                url += "&difficulty=" + (PluginSettings::SearchingDifficultys.Find(PluginSettings::Difficulty)-1);
+                params.Set("difficulty", tostring(PluginSettings::SearchingDifficultys.Find(PluginSettings::Difficulty)-1));
             }
             if (PluginSettings::MapAuthor != "") {
-                url += "&author=" + Net::UrlEncode(PluginSettings::MapAuthor);
+                params.Set("author", Net::UrlEncode(PluginSettings::MapAuthor)); // TODO this won't work with multiple authors
             }
             if (PluginSettings::MapName != "") {
-                url += "&trackname=" + Net::UrlEncode(PluginSettings::MapName);
+                params.Set("name", Net::UrlEncode(PluginSettings::MapName));
             }
             if (PluginSettings::MapPackID != 0) {
-                url += "&mid=" + PluginSettings::MapPackID;
+                params.Set("mappackid", tostring(PluginSettings::MapPackID));
             }
         }
 
 #if TMNEXT
             // prevent loading CharacterPilot maps
-            url += "&vehicles=1,2,3,4";
+            params.Set("vehicle", "1,2,3,4");
+
+            if ((RMC::IsRunning || RMC::IsStarting) && PluginSettings::RMC_GoalMedal == RMC::Medals[4]) {
+                // We only want maps with a WR
+                params.Set("inhasrecord", "1");
+            }
 #elif MP4
             // Fetch in the correct titlepack
-            if (TM::CurrentTitlePack() == "TMAll") {
-                url += "&tpack=" + TM::CurrentTitlePack()+"&tpack=TMCanyon&tpack=TMValley&tpack=TMStadium&tpack=TMLagoon";
+            if (TM::CurrentTitlePack() == "TMAll" && false) {
+                params.Set("titlepack", TM::CurrentTitlePack()+"&titlepack=TMCanyon&titlepack=TMValley&titlepack=TMStadium&titlepack=TMLagoon"); // TODO doesn't work
             } else {
-                url += "&tpack=" + TM::CurrentTitlePack();
+                params.Set("titlepack", TM::CurrentTitlePack());
             }
 #endif
 
         // prevent loading non-Race maps (Royal, flagrush etc...)
-        url += "&mtype="+SUPPORTED_MAP_TYPE;
+        params.Set("maptype", SUPPORTED_MAP_TYPE);
 
-        return url;
+        string urlParams = DictToApiParams(params);
+        return url + urlParams;
     }
 
     int GetMinimumLength() {
@@ -345,5 +377,22 @@ namespace MX
         } else {
             return requiredLength;
         }
+    }
+
+    string DictToApiParams(dictionary params) {
+        string urlParams = "";
+        if (!params.IsEmpty()) {
+            auto keys = params.GetKeys();
+            for (uint i = 0; i < keys.Length; i++) {
+                string key = keys[i];
+                string value;
+                params.Get(key, value);
+
+                urlParams += (i == 0 ? "?" : "&");
+                urlParams += key + "=" + Net::UrlEncode(value);
+            }
+        }
+
+        return urlParams;
     }
 }

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -84,7 +84,7 @@ namespace MX
                 // if we do not detect that there are no matching results, we will enter an infinite loop with errors
                 // that will force the user to reload the plugin
                 Json::Value check = CheckCustomRulesParametersNoResults();
-                if (check.HasKey("TrackID")) {
+                if (check.HasKey("MapId")) {
                     // we found a single map that matches the parameters, so we can just return it
                     res = check;
                 } else if (check.HasKey("hasMaps")) {
@@ -126,18 +126,18 @@ namespace MX
 #if TMNEXT
         // Check if map is uploaded to Nadeo Services (if goal == WorldRecord)
         if ((RMC::IsRunning || RMC::IsStarting) && PluginSettings::RMC_GoalMedal == RMC::Medals[4]) {
-            if (!MXNadeoServicesGlobal::CheckIfMapExistsAsync(map.TrackUID)) {
+            if (!MXNadeoServicesGlobal::CheckIfMapExistsAsync(map.MapUid)) {
                 Log::Warn("Map is not uploaded to Nadeo Services, retrying...");
                 PreloadRandomMap();
                 return;
             } else {
                 // if uploaded, get wr
-                uint mapWorldRecord = MXNadeoServicesGlobal::GetMapWorldRecord(map.TrackUID);
+                uint mapWorldRecord = MXNadeoServicesGlobal::GetMapWorldRecord(map.MapUid);
                 if (int(mapWorldRecord) == -1) {
                     Log::Warn("Couldn't got map World Record, retrying another map...");
                     PreloadRandomMap();
                     return;
-                } else TM::SetWorldRecordToCache(map.TrackUID, mapWorldRecord);
+                } else TM::SetWorldRecordToCache(map.MapUid, mapWorldRecord);
             }
         }
 #endif
@@ -307,10 +307,10 @@ namespace MX
 #if DEPENDENCY_CHAOSMODE
             if (ChaosMode::IsInRMCMode()) {
                 Log::Trace("Loading map in Chaos Mode");
-                app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID, "TrackMania/ChaosModeRMC", "");
+                app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.MapId, "TrackMania/ChaosModeRMC", "");
             } else
 #endif
-            app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.TrackID, DEFAULT_MODE, "");
+            app.ManiaTitleControlScriptAPI.PlayMap(PluginSettings::RMC_MX_Url+"/maps/download/"+map.MapId, DEFAULT_MODE, "");
             RMC::CurrentMapJsonData = map.ToJson();
         }
         catch

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -77,10 +77,10 @@ namespace MX
     }
 
     bool isMapInsideDateParams(const MX::MapInfo@ &in map) {
-        int64 mapUploadedDate = DateFromStrTime(map.UploadedAt);
-        int64 mapUpdatedDate = DateFromStrTime(map.UpdatedAt);
-        int64 toDate = DateFromStrTime(PluginSettings::ToYear + "-" + Text::Format("%.02d", PluginSettings::ToMonth) + "-" + Text::Format("%.02d", PluginSettings::ToDay) + "T00:00:00.00");
-        int64 fromDate = DateFromStrTime(PluginSettings::FromYear + "-" + Text::Format("%.02d", PluginSettings::FromMonth) + "-" + Text::Format("%.02d", PluginSettings::FromDay) + "T00:00:00.00");
+        int64 mapUploadedDate = Time::ParseFormatString('%FT%T', map.UploadedAt);
+        int64 mapUpdatedDate = Time::ParseFormatString('%FT%T', map.UpdatedAt);
+        int64 toDate = Time::ParseFormatString('%F', PluginSettings::ToYear + "-" + Text::Format("%.02d", PluginSettings::ToMonth) + "-" + Text::Format("%.02d", PluginSettings::ToDay));
+        int64 fromDate = Time::ParseFormatString('%F', PluginSettings::FromYear + "-" + Text::Format("%.02d", PluginSettings::FromMonth) + "-" + Text::Format("%.02d", PluginSettings::FromDay));
         return (mapUpdatedDate < toDate && mapUpdatedDate > fromDate);
     }
 

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -309,7 +309,8 @@ namespace MX
                 params.Set("difficulty", tostring(PluginSettings::SearchingDifficultys.Find(PluginSettings::Difficulty)-1));
             }
             if (PluginSettings::MapAuthor != "") {
-                params.Set("author", Net::UrlEncode(PluginSettings::MapAuthor)); // TODO this won't work with multiple authors
+                if (PluginSettings::MapAuthor.Contains(",")) PluginSettings::MapAuthor = PluginSettings::MapAuthor.Split(",")[0];
+                params.Set("author", Net::UrlEncode(PluginSettings::MapAuthor));
             }
             if (PluginSettings::MapName != "") {
                 params.Set("name", Net::UrlEncode(PluginSettings::MapName));

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -391,7 +391,7 @@ namespace MX
                 params.Get(key, value);
 
                 urlParams += (i == 0 ? "?" : "&");
-                urlParams += key + "=" + Net::UrlEncode(value);
+                urlParams += key + "=" + Net::UrlEncode(value.Trim());
             }
         }
 

--- a/src/Utils/MX/Methods/LoadRandomMap.as
+++ b/src/Utils/MX/Methods/LoadRandomMap.as
@@ -119,17 +119,6 @@ namespace MX
             }
         }
         Log::Trace("PreloadRandomMapRes: "+Json::Write(res));
-
-        Json::Value playedAt = Json::Object();
-        Time::Info date = Time::Parse();
-        playedAt["Year"] = date.Year;
-        playedAt["Month"] = date.Month;
-        playedAt["Day"] = date.Day;
-        playedAt["Hour"] = date.Hour;
-        playedAt["Minute"] = date.Minute;
-        playedAt["Second"] = date.Second;
-        res["PlayedAt"] = playedAt;
-
         MX::MapInfo@ map = MX::MapInfo(res);
 
         if (map is null){
@@ -210,16 +199,7 @@ namespace MX
             MX::MapInfo@ map;
             if (RMC::ContinueSavedRun && !RMC::IsInited) {
                 Json::Value res = RMC::CurrentMapJsonData;
-                Json::Value playedAt = Json::Object();
-                Time::Info date = Time::Parse();
-                playedAt["Year"] = date.Year;
-                playedAt["Month"] = date.Month;
-                playedAt["Day"] = date.Day;
-                playedAt["Hour"] = date.Hour;
-                playedAt["Minute"] = date.Minute;
-                playedAt["Second"] = date.Second;
-                res["PlayedAt"] = playedAt;
-
+                res["PlayedAt"] = Time::Stamp; // Update to the last time it was played
                 @map = MX::MapInfo(res);
                 @preloadedMap = null;
             } else {

--- a/src/Utils/Migration.as
+++ b/src/Utils/Migration.as
@@ -188,7 +188,7 @@ namespace Migration
                         MX::MapInfo@ currMap = v2_maps[i];
 
                         if (mapData["TrackID"] == currMap.MapId) {
-                            currMap.PlayedAt = mapData["PlayedAt"];
+                            currMap.PlayedAt = TimestampFromObject(mapData["PlayedAt"]);
                             save["MapData"] = currMap.ToJson();
 
                             Json::ToFile(oldSaves[f], save);
@@ -209,7 +209,7 @@ namespace Migration
                     MX::MapInfo@ map = v2_maps[i];                    
 
                     if (map.MapId == oldMap["TrackID"]) {
-                        map.PlayedAt = map["PlayedAt"];
+                        map.PlayedAt = TimestampFromObject(oldMap["PlayedAt"]);
                         DataJson["recentlyPlayed"].Add(map.ToJson());
                         break;
                     }

--- a/src/Utils/Migration.as
+++ b/src/Utils/Migration.as
@@ -22,7 +22,7 @@ namespace Migration
     void StartRequestMapsInfo(array<int> MXIds)
     {
         array<MX::MapInfo@> Maps;
-        string url = PluginSettings::RMC_MX_Url+"/api/maps/get_map_info/multi/";
+        string url = PluginSettings::RMC_MX_Url + "/api/maps?fields=" + MAP_FIELDS + "&count=50&id=";
         string mapIdsStr = "";
 
         for (uint i = 0; i < MXIds.Length; i++)
@@ -42,23 +42,24 @@ namespace Migration
             Log::Trace("Migration::CheckRequest : " + res);
             auto json = Json::Parse(res);
 
-            if (json.GetType() != Json::Type::Array) {
-                print("Migration::CheckRequest : Json is not an array");
+            if (json.GetType() != Json::Type::Object) {
+                print("Migration::CheckRequest : Json is not an object");
                 requestError = true;
                 return;
             }
 
-            if (json.Length < 1) {
+            if (json.Length == 0 || !json.HasKey("Results") || json["Results"].Length == 0) {
                 print("Migration::CheckRequest : Error parsing response");
                 requestError = true;
                 return;
             }
 
+            Json::Value@ maps = json["Results"];
+
             // Handle the response
-            for (uint i = 0; i < json.Length; i++)
+            for (uint i = 0; i < maps.Length; i++)
             {
-                Json::Value MapJson = json[i];
-                MX::MapInfo@ Map = MX::MapInfo(MapJson);
+                MX::MapInfo@ Map = MX::MapInfo(maps[i]);
                 RecentlyPlayed.InsertLast(Map);
             }
             @n_request = null;

--- a/src/Utils/Migration.as
+++ b/src/Utils/Migration.as
@@ -229,6 +229,27 @@ namespace Migration
         DataManager::SaveData();
     }
 
+    void BackupData() {
+        if (!IO::FolderExists(MX_V1_BACKUP_LOCATION)) {
+            IO::CreateFolder(MX_V1_BACKUP_LOCATION);
+        }
+
+        IO::Copy(DATA_JSON_LOCATION, Path::Join(MX_V1_BACKUP_LOCATION, "MXRandom_Data.json"));
+
+        string backupSavePath = Path::Join(MX_V1_BACKUP_LOCATION, "Save/");
+
+        if (!IO::FolderExists(backupSavePath)) {
+            IO::CreateFolder(backupSavePath);
+        }
+
+        for (uint f = 0; f < oldSaves.Length; f++) {
+            string fileName = Path::GetFileName(oldSaves[f]);
+            IO::Copy(oldSaves[f], backupSavePath + fileName);
+        }
+
+        Log::Log("Succesfully backed up old data at " + MX_V1_BACKUP_LOCATION);
+    }
+
     void RemoveMX1SaveFiles() {
         for (uint f = 0; f < oldSaves.Length; f++) {
             IO::Delete(oldSaves[f]);

--- a/src/Utils/Migration.as
+++ b/src/Utils/Migration.as
@@ -1,5 +1,7 @@
 namespace Migration
 {
+    // Migrates data to version 2 of the plugin
+
     Json::Value RecentlyPlayedJson = Json::FromFile(IO::FromDataFolder("TMXRandom_PlayedMaps.json"));
     Net::HttpRequest@ n_request;
     array<MX::MapInfo@> RecentlyPlayed;
@@ -76,5 +78,160 @@ namespace Migration
         }
         DataManager::SaveData();
         IO::Delete(IO::FromDataFolder("TMXRandom_PlayedMaps.json"));
+    }
+
+    // Migrates data and settings to MX 2.0
+
+    [Setting hidden]
+    bool MigratedToMX2 = false;
+
+    Net::HttpRequest@ v2_request;
+    bool v2_requestError;
+    array<string> oldSaves = IO::IndexFolder(SAVE_DATA_LOCATION, true);
+    Json::Value oldPlayed = DataJson["recentlyPlayed"];
+    array<MX::MapInfo@> v2_maps;
+
+    void MigrateMX1Settings() {
+        if (PluginSettings::RMC_MX_Url == "https://map-monitor.xk.io") {
+            PluginSettings::RMC_MX_Url = "https://" + MX_URL;
+        }
+
+        if (PluginSettings::MapLength == "Longer than 5 minutes") {
+            PluginSettings::MapLength = "Anything";
+        }
+
+        if (PluginSettings::MapAuthor.Contains(",")) {
+            // MX 2.0 doesn't allow filtering by multiple authors yet
+            PluginSettings::MapAuthor = PluginSettings::MapAuthor.Split(",")[0];
+        }
+    }
+
+    array<int> GetMX1MapsId() {
+        array<int> MXIds;
+
+        for (uint f = 0; f < oldSaves.Length; f++) {
+            Json::Value@ save = Json::FromFile(oldSaves[f]);
+
+            if (save.HasKey("MapData")) {
+                Json::Value@ mapData = save["MapData"];
+
+                if (mapData.HasKey("TrackID") && MXIds.Find(mapData["TrackID"]) == -1) {
+                    MXIds.InsertLast(mapData["TrackID"]);
+                }
+            }
+        }
+
+        if (DataJson.GetType() == Json::Type::Null) return MXIds;
+
+        for (uint i = 0; i < DataJson["recentlyPlayed"].Length; i++) {
+            Json::Value@ map = DataJson["recentlyPlayed"][i];
+
+            if (map.HasKey("TrackID") && MXIds.Find(map["TrackID"]) == -1) {
+                MXIds.InsertLast(map["TrackID"]);
+            }
+        }
+
+        return MXIds;
+    }
+
+    void StartMX2RequestMapsInfo(array<int> MXIds) {
+        array<MX::MapInfo@> Maps;
+        string url = PluginSettings::RMC_MX_Url + "/api/maps?fields=" + MAP_FIELDS + "&count=" + MXIds.Length + "&id=";
+        string mapIdsStr = "";
+
+        for (uint i = 0; i < MXIds.Length; i++) {
+            mapIdsStr += tostring(MXIds[i]);
+            if (i < MXIds.Length - 1) mapIdsStr += ",";
+        }
+
+        @v2_request = API::Get(url + mapIdsStr);
+    }
+
+    void CheckMX2MigrationRequest() {
+        if (v2_request !is null && v2_request.Finished()) {
+            string res = v2_request.String();
+            Log::Trace("Migration::CheckV2MXRequest: " + res);
+            auto json = Json::Parse(res);
+
+            if (json.GetType() != Json::Type::Object) {
+                print("Migration::CheckV2MXRequest: Json is not an object");
+                v2_requestError = true;
+                return;
+            }
+
+            if (json.Length == 0 || !json.HasKey("Results") || json["Results"].Length == 0) {
+                print("Migration::CheckV2MXRequest: Error parsing response");
+                v2_requestError = true;
+                return;
+            }
+
+            Json::Value@ maps = json["Results"];
+
+            for (uint i = 0; i < maps.Length; i++) {
+                MX::MapInfo@ Map = MX::MapInfo(maps[i]);
+                v2_maps.InsertLast(Map);
+            }
+
+            @v2_request = null;
+        }
+    }
+
+    void UpdateData() {
+        for (uint f = 0; f < oldSaves.Length; f++) {
+            Json::Value@ save = Json::FromFile(oldSaves[f]);
+
+            if (save.HasKey("MapData")) {
+                Json::Value@ mapData = save["MapData"];
+
+                if (mapData.HasKey("TrackID")) {
+                    for (uint i = 0; i < v2_maps.Length; i++) {
+                        MX::MapInfo@ currMap = v2_maps[i];
+
+                        if (mapData["TrackID"] == currMap.MapId) {
+                            currMap.PlayedAt = mapData["PlayedAt"];
+                            save["MapData"] = currMap.ToJson();
+
+                            Json::ToFile(oldSaves[f], save);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        dictionary playedMap;
+
+        for (uint p = 0; p < oldPlayed.Length; p++) {
+            Json::Value@ map = oldPlayed[p];
+
+            if (map.HasKey("TrackID")) {
+                string trackId = tostring(int(map["TrackID"]));
+
+                if (!playedMap.Exists(trackId)) {
+                    playedMap.Set(trackId, Json::Write(map["PlayedAt"]));
+                }
+            }
+        }
+
+        DataManager::InitData(false);
+
+        for (uint i = 0; i < v2_maps.Length; i++) {
+            MX::MapInfo@ currMap = v2_maps[i];
+            string playedAt;
+
+            if (playedMap.Get(tostring(currMap.MapId), playedAt)) {
+                currMap.PlayedAt = Json::Parse(playedAt);
+                Json::Value MapJson = currMap.ToJson();
+                DataJson["recentlyPlayed"].Add(MapJson);
+            }
+        }
+
+        DataManager::SaveData();
+    }
+
+    void RemoveMX1SaveFiles() {
+        for (uint f = 0; f < oldSaves.Length; f++) {
+            IO::Delete(oldSaves[f]);
+        }
     }
 }

--- a/src/Utils/Migration.as
+++ b/src/Utils/Migration.as
@@ -199,30 +199,21 @@ namespace Migration
             }
         }
 
-        dictionary playedMap;
-
-        for (uint p = 0; p < oldPlayed.Length; p++) {
-            Json::Value@ map = oldPlayed[p];
-
-            if (map.HasKey("TrackID")) {
-                string trackId = tostring(int(map["TrackID"]));
-
-                if (!playedMap.Exists(trackId)) {
-                    playedMap.Set(trackId, Json::Write(map["PlayedAt"]));
-                }
-            }
-        }
-
         DataManager::InitData(false);
 
-        for (uint i = 0; i < v2_maps.Length; i++) {
-            MX::MapInfo@ currMap = v2_maps[i];
-            string playedAt;
+        for (uint p = 0; p < oldPlayed.Length; p++) {
+            Json::Value@ oldMap = oldPlayed[p];
 
-            if (playedMap.Get(tostring(currMap.MapId), playedAt)) {
-                currMap.PlayedAt = Json::Parse(playedAt);
-                Json::Value MapJson = currMap.ToJson();
-                DataJson["recentlyPlayed"].Add(MapJson);
+            if (oldMap.HasKey("TrackID")) {
+                for (uint i = 0; i < v2_maps.Length; i++) {
+                    MX::MapInfo@ map = v2_maps[i];                    
+
+                    if (map.MapId == oldMap["TrackID"]) {
+                        map.PlayedAt = map["PlayedAt"];
+                        DataJson["recentlyPlayed"].Add(map.ToJson());
+                        break;
+                    }
+                }
             }
         }
 

--- a/src/Utils/Migration.as
+++ b/src/Utils/Migration.as
@@ -236,7 +236,7 @@ namespace Migration
 
         IO::Copy(DATA_JSON_LOCATION, Path::Join(MX_V1_BACKUP_LOCATION, "MXRandom_Data.json"));
 
-        string backupSavePath = Path::Join(MX_V1_BACKUP_LOCATION, "Save/");
+        string backupSavePath = Path::Join(MX_V1_BACKUP_LOCATION, "Saves/");
 
         if (!IO::FolderExists(backupSavePath)) {
             IO::CreateFolder(backupSavePath);

--- a/src/Utils/RMC/GlobalProperties.as
+++ b/src/Utils/RMC/GlobalProperties.as
@@ -37,18 +37,7 @@ namespace RMC
 #endif
     };
 
-    const array<string> allowedMapLengths = {
-        "15 secs",
-        "30 secs",
-        "45 secs",
-        "1 min",
-        "1 m 15 s",
-        "1 m 30 s",
-        "1 m 45 s",
-        "2 min",
-        "2 m 30 s",
-        "3 min"
-    };
+    const int allowedMaxLength = 180000;
 
     RMC@ Challenge;
     RMS@ Survival;

--- a/src/Utils/RMC/ObjectiveMode.as
+++ b/src/Utils/RMC/ObjectiveMode.as
@@ -132,7 +132,7 @@ class RMObjective : RMC
                 if (currentMap !is null) {
                     CGameCtnChallengeInfo@ currentMapInfo = currentMap.MapInfo;
                     if (currentMapInfo !is null) {
-                        if (DataJson["recentlyPlayed"].Length > 0 && currentMapInfo.MapUid == DataJson["recentlyPlayed"][0]["TrackUID"]) {
+                        if (DataJson["recentlyPlayed"].Length > 0 && currentMapInfo.MapUid == DataJson["recentlyPlayed"][0]["MapUid"]) {
                             RMC::StartTime = Time::get_Now();
                             PendingTimerLoop();
 

--- a/src/Utils/RMC/RMC.as
+++ b/src/Utils/RMC/RMC.as
@@ -178,7 +178,7 @@ class RMC
         if (currentMap !is null) {
             CGameCtnChallengeInfo@ currentMapInfo = currentMap.MapInfo;
             if (currentMapInfo !is null) {
-                if (DataJson["recentlyPlayed"].Length > 0 && currentMapInfo.MapUid == DataJson["recentlyPlayed"][0]["TrackUID"]) {
+                if (DataJson["recentlyPlayed"].Length > 0 && currentMapInfo.MapUid == DataJson["recentlyPlayed"][0]["MapUid"]) {
                     UI::Separator();
                     MX::MapInfo@ CurrentMapFromJson = MX::MapInfo(DataJson["recentlyPlayed"][0]);
                     if (CurrentMapFromJson !is null) {
@@ -239,7 +239,7 @@ class RMC
         CGameCtnChallenge@ currentMap = cast<CGameCtnChallenge>(GetApp().RootMap);
         if (currentMap !is null) {
             CGameCtnChallengeInfo@ currentMapInfo = currentMap.MapInfo;
-            if (DataJson["recentlyPlayed"].Length > 0 && currentMapInfo.MapUid == DataJson["recentlyPlayed"][0]["TrackUID"]) {
+            if (DataJson["recentlyPlayed"].Length > 0 && currentMapInfo.MapUid == DataJson["recentlyPlayed"][0]["MapUid"]) {
                 PausePlayButton();
                 UI::SameLine();
                 SkipButtons();
@@ -423,7 +423,7 @@ class RMC
                 if (currentMap !is null) {
                     CGameCtnChallengeInfo@ currentMapInfo = currentMap.MapInfo;
                     if (currentMapInfo !is null) {
-                        if (DataJson["recentlyPlayed"].Length > 0 && currentMapInfo.MapUid == DataJson["recentlyPlayed"][0]["TrackUID"]) {
+                        if (DataJson["recentlyPlayed"].Length > 0 && currentMapInfo.MapUid == DataJson["recentlyPlayed"][0]["MapUid"]) {
                             RMC::StartTime = Time::Now;
                             RMC::TimeSpentMap = Time::Now - RMC::TimeSpawnedMap;
                             PendingTimerLoop();

--- a/src/Utils/RMC/RMT.as
+++ b/src/Utils/RMC/RMT.as
@@ -113,15 +113,6 @@ class RMT : RMC
             SetupMapStart();
             return;
         }
-        Json::Value playedAt = Json::Object();
-        Time::Info date = Time::Parse();
-        playedAt["Year"] = date.Year;
-        playedAt["Month"] = date.Month;
-        playedAt["Day"] = date.Day;
-        playedAt["Hour"] = date.Hour;
-        playedAt["Minute"] = date.Minute;
-        playedAt["Second"] = date.Second;
-        res["PlayedAt"] = playedAt;
         @currentMap = MX::MapInfo(res);
         Log::Trace("RMT: Random map: " + currentMap.Name + " (" + currentMap.MapId + ")");
         seenMaps[currentMap.MapUid] = currentMap.MapUid;
@@ -172,15 +163,6 @@ class RMT : RMC
             RMTFetchNextMap();
             return;
         }
-        Json::Value playedAt = Json::Object();
-        Time::Info date = Time::Parse();
-        playedAt["Year"] = date.Year;
-        playedAt["Month"] = date.Month;
-        playedAt["Day"] = date.Day;
-        playedAt["Hour"] = date.Hour;
-        playedAt["Minute"] = date.Minute;
-        playedAt["Second"] = date.Second;
-        res["PlayedAt"] = playedAt;
         @nextMap = MX::MapInfo(res);
         Log::Trace("RMT: Next Random map: " + nextMap.Name + " (" + nextMap.MapId + ")");
 

--- a/src/Utils/RMC/RMT.as
+++ b/src/Utils/RMC/RMT.as
@@ -107,7 +107,7 @@ class RMT : RMC
         Log::Trace("RMT: Fetching a random map...");
         Json::Value res;
         try {
-            res = API::GetAsync(MX::CreateQueryURL())["results"][0];
+            res = API::GetAsync(MX::CreateQueryURL())["Results"][0];
         } catch {
             Log::Error("ManiaExchange API returned an error, retrying...", true);
             SetupMapStart();
@@ -166,7 +166,7 @@ class RMT : RMC
         Log::Trace("RMT: Fetching a random map...");
         Json::Value res;
         try {
-            res = API::GetAsync(MX::CreateQueryURL())["results"][0];
+            res = API::GetAsync(MX::CreateQueryURL())["Results"][0];
         } catch {
             Log::Error("ManiaExchange API returned an error, retrying...");
             RMTFetchNextMap();

--- a/src/Utils/RMC/RMT.as
+++ b/src/Utils/RMC/RMT.as
@@ -123,19 +123,19 @@ class RMT : RMC
         playedAt["Second"] = date.Second;
         res["PlayedAt"] = playedAt;
         @currentMap = MX::MapInfo(res);
-        Log::Trace("RMT: Random map: " + currentMap.Name + " (" + currentMap.TrackID + ")");
-        seenMaps[currentMap.TrackUID] = currentMap.TrackUID;
+        Log::Trace("RMT: Random map: " + currentMap.Name + " (" + currentMap.MapId + ")");
+        seenMaps[currentMap.MapUid] = currentMap.MapUid;
         UI::ShowNotification(Icons::InfoCircle + " RMT - Information on map switching", "Nadeo prevent sometimes when switching map too often and will not change map.\nIf after 10 seconds the podium screen is not shown, you can start a vote to change to next map in the game pause menu.", Text::ParseHexColor("#420399"));
 
-        if (!MXNadeoServicesGlobal::CheckIfMapExistsAsync(currentMap.TrackUID)) {
+        if (!MXNadeoServicesGlobal::CheckIfMapExistsAsync(currentMap.MapUid)) {
             Log::Trace("RMT: Map is not on NadeoServices, retrying...");
             SetupMapStart();
             return;
         }
 
         DataManager::SaveMapToRecentlyPlayed(currentMap);
-        MXNadeoServicesGlobal::ClubRoomSetMapAndSwitchAsync(RMTRoom, currentMap.TrackUID);
-        while (!TM::IsMapCorrect(currentMap.TrackUID)) sleep(1000);
+        MXNadeoServicesGlobal::ClubRoomSetMapAndSwitchAsync(RMTRoom, currentMap.MapUid);
+        while (!TM::IsMapCorrect(currentMap.MapUid)) sleep(1000);
         MXNadeoServicesGlobal::ClubRoomSetCountdownTimer(RMTRoom, TimeLimit() / 1000);
         while (GetApp().CurrentPlayground is null) yield();
         CGamePlayground@ GamePlayground = cast<CGamePlayground>(GetApp().CurrentPlayground);
@@ -182,19 +182,19 @@ class RMT : RMC
         playedAt["Second"] = date.Second;
         res["PlayedAt"] = playedAt;
         @nextMap = MX::MapInfo(res);
-        Log::Trace("RMT: Next Random map: " + nextMap.Name + " (" + nextMap.TrackID + ")");
+        Log::Trace("RMT: Next Random map: " + nextMap.Name + " (" + nextMap.MapId + ")");
 
         if (PluginSettings::SkipSeenMaps) {
-            if (seenMaps.Exists(nextMap.TrackUID)) {
+            if (seenMaps.Exists(nextMap.MapUid)) {
                 Log::Trace("Map has been seen, retrying...");
                 RMTFetchNextMap();
                 return;
             }
 
-            seenMaps[nextMap.TrackUID] = nextMap.TrackUID;
+            seenMaps[nextMap.MapUid] = nextMap.MapUid;
         }
 
-        if (!MXNadeoServicesGlobal::CheckIfMapExistsAsync(nextMap.TrackUID)) {
+        if (!MXNadeoServicesGlobal::CheckIfMapExistsAsync(nextMap.MapUid)) {
             Log::Trace("RMT: Next map is not on NadeoServices, retrying...");
             @nextMap = null;
             RMTFetchNextMap();
@@ -216,12 +216,12 @@ class RMT : RMC
         while (isFetchingNextMap) yield();
         @currentMap = nextMap;
         @nextMap = null;
-        Log::Trace("RMT: Random map: " + currentMap.Name + " (" + currentMap.TrackID + ")");
+        Log::Trace("RMT: Random map: " + currentMap.Name + " (" + currentMap.MapId + ")");
         UI::ShowNotification(Icons::InfoCircle + " RMT - Information on map switching", "Nadeo prevent sometimes when switching map too often and will not change map.\nIf after 10 seconds the podium screen is not shown, you can start a vote to change to next map in the game pause menu.", Text::ParseHexColor("#420399"));
 
         DataManager::SaveMapToRecentlyPlayed(currentMap);
-        MXNadeoServicesGlobal::ClubRoomSetMapAndSwitchAsync(RMTRoom, currentMap.TrackUID);
-        while (!TM::IsMapCorrect(currentMap.TrackUID)) sleep(1000);
+        MXNadeoServicesGlobal::ClubRoomSetMapAndSwitchAsync(RMTRoom, currentMap.MapUid);
+        while (!TM::IsMapCorrect(currentMap.MapUid)) sleep(1000);
         MXNadeoServicesGlobal::ClubRoomSetCountdownTimer(RMTRoom, RMTTimerMapChange / 1000);
         while (GetApp().CurrentPlayground is null) yield();
         CGamePlayground@ GamePlayground = cast<CGamePlayground>(GetApp().CurrentPlayground);


### PR DESCRIPTION
Like with the ManiaExchange plugin, this PR migrates the plugin to MX 2.0. Functionality should be almost the same, besides some filters/options that don't exist on the new site

This also adds a modal dialog to migrate the already existing 1.0 data to 2.0. This is mainly based on the previous data migration process done by the plugin

I couldn't find any issues when testing on both TM2 and TMNEXT, but I highly recommend testing the changes if possible

P.S.: I also added a check for the new ServerSizeExceeded value. Fixes #140 