### PR TITLE
fix medal count alignment and overlaps

### DIFF
--- a/src/Utils/RMC/RMC.as
+++ b/src/Utils/RMC/RMC.as
@@ -156,6 +156,8 @@ class RMC
     {
         if (PluginSettings::RMC_GoalMedal != RMC::Medals[0])
         {
+            vec2 pos_orig = UI::GetCursorPos();
+            UI::SetCursorPos(vec2(pos_orig.x + (13 * tostring(RMC::GoalMedalCount).get_Length()), pos_orig.y));
             UI::AlignTextToFramePadding();
 #if TMNEXT
             if (PluginSettings::RMC_GoalMedal == RMC::Medals[4]) UI::Image(AuthorTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
@@ -165,7 +167,7 @@ class RMC
             else if (PluginSettings::RMC_GoalMedal == RMC::Medals[1]) UI::Image(BronzeTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
             else UI::Text(PluginSettings::RMC_GoalMedal);
             UI::SameLine();
-            vec2 pos_orig = UI::GetCursorPos();
+            pos_orig = UI::GetCursorPos();
             UI::SetCursorPos(vec2(pos_orig.x, pos_orig.y+8));
             UI::PushFont(TimerFont);
             UI::Text(tostring(BelowMedalCount));

--- a/src/Utils/RMC/RMS.as
+++ b/src/Utils/RMC/RMS.as
@@ -45,9 +45,12 @@ class RMS : RMC
 
     void RenderBelowGoalMedal() override
     {
+        vec2 pos_orig = UI::GetCursorPos();
+        UI::SetCursorPos(vec2(pos_orig.x + (13 * tostring(RMC::GoalMedalCount).get_Length()), pos_orig.y));
+        UI::AlignTextToFramePadding();
         UI::Image(SkipTex, vec2(PluginSettings::RMC_ImageSize*2,PluginSettings::RMC_ImageSize*2));
         UI::SameLine();
-        vec2 pos_orig = UI::GetCursorPos();
+        pos_orig = UI::GetCursorPos();
         UI::SetCursorPos(vec2(pos_orig.x, pos_orig.y+8));
         UI::PushFont(TimerFont);
         UI::Text(tostring(Skips));


### PR DESCRIPTION
- Fixes alignment of skip count text in RMS overlay
- Fixes AT (goal) medal count overlap with belowgoalmedalcount when it's too big (i.e > 100)

Before (note how the 0 skips is slightly unaligned upwards): 
![image](https://github.com/user-attachments/assets/9b65a335-5f6e-475a-80d7-7095288bf5b1)

After:
![image](https://github.com/user-attachments/assets/0eaca232-439f-4074-b25e-529ced01661f)
